### PR TITLE
Rpp version update for release/rocm-rel-6.0

### DIFF
--- a/MIVisionX-setup.py
+++ b/MIVisionX-setup.py
@@ -43,8 +43,8 @@ parser.add_argument('--opencv',    	type=str, default='4.6.0',
                     help='OpenCV Version - optional (default:4.6.0)')
 parser.add_argument('--protobuf',  	type=str, default='3.12.4',
                     help='ProtoBuf Version - optional (default:3.12.4)')
-parser.add_argument('--rpp',   		type=str, default='1.2.0',
-                    help='RPP Version - optional (default:1.2.0)')
+parser.add_argument('--rpp',   		type=str, default='1.4.0',
+                    help='RPP Version - optional (default:1.4.0)')
 parser.add_argument('--pybind11',   type=str, default='v2.10.4',
                     help='PyBind11 Version - optional (default:v2.10.4)')
 parser.add_argument('--ffmpeg',    	type=str, default='ON',


### PR DESCRIPTION
RPP install fails for QA team installing MIVisionX dependencies using MIVisionX-setup.py with release/rocm-rel-6.0 branch in MI300 systems (with rocm 6.0). The error is due to a [deprecated](https://github.com/ROCm/rpp/issues/192) HIP API in rpp. The [fix](https://github.com/ROCm/rpp/commit/2795f02839c6f5885d2cd954de6c6ad94c3a0d94) is added in rpp version 1.4.0 but release/rocm-rel-6.0 still has the 1.2.0 version as default rpp version.