### PR TITLE
Std filesystem cmake fix

### DIFF
--- a/rocAL/rocAL/CMakeLists.txt
+++ b/rocAL/rocAL/CMakeLists.txt
@@ -42,7 +42,7 @@ find_package(RapidJSON QUIET)
 
 # Check for filesystem support
 include(CheckCXXSourceCompiles)
-set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS}")
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
 set(CMAKE_REQUIRED_INCLUDES "")
 check_cxx_source_compiles("#include <filesystem>\nnamespace fs = std::filesystem;\nint main() { return 0; }" HAS_STD_FILESYSTEM)
 check_cxx_source_compiles("#include <experimental/filesystem>\nnamespace fs = std::experimental::filesystem;\nint main() { return 0; }" HAS_EXP_FILESYSTEM)


### PR DESCRIPTION
Even for newer gcc and clang versions, the -std=gnu++17 argument must be added for supporting std::filesystem features while compiling. Due to the missed argument, even gcc versions > 9 with std::filesystem added in libstdc++ fails the compilation test and std::experimental::filesystem is used instead.