### PR TITLE
Linting fixes for PEP-8 conformance.

### DIFF
--- a/MIVisionX-setup.py
+++ b/MIVisionX-setup.py
@@ -167,13 +167,13 @@ if "centos" in platfromInfo or "redhat" in platfromInfo or os.path.exists('/usr/
     if "centos-7" in platfromInfo or "redhat-7" in platfromInfo:
         linuxCMake = 'cmake3'
         os.system(linuxSystemInstall+' install cmake3')
-    if not "centos" in platfromInfo or not "redhat" in platfromInfo:
+    if "centos" not in platfromInfo or "redhat" not in platfromInfo:
         platfromInfo = platfromInfo+'-redhat'
 elif "Ubuntu" in platfromInfo or os.path.exists('/usr/bin/apt-get'):
     linuxSystemInstall = 'apt-get -y'
     linuxSystemInstall_check = '--allow-unauthenticated'
     linuxFlag = '-S'
-    if not "Ubuntu" in platfromInfo:
+    if "Ubuntu" not in platfromInfo:
         platfromInfo = platfromInfo+'-Ubuntu'
 elif os.path.exists('/usr/bin/zypper'):
     linuxSystemInstall = 'zypper -n'

--- a/apps/mivisionx_inference_analyzer/mivisionx_inference_analyzer.py
+++ b/apps/mivisionx_inference_analyzer/mivisionx_inference_analyzer.py
@@ -30,7 +30,7 @@ colors =[
         (153,76,0),       # Top3
         (0,128,255),      # Top4
         (255,102,102),    # Top5
-        ];
+        ]
 
 # AMD Neural Net python wrapper
 class AnnAPI:
@@ -68,7 +68,7 @@ class annieObjectWrapper():
             output,opName,n_o,c_o,h_o,w_o = output_info.split(',')
         else:
             output,opName,n_o,c_o= output_info.split(',')
-            h_o = '1'; w_o  = '1';
+            h_o = '1'; w_o  = '1'
         self.hdl = self.api.annCreateInference(weightsfile.encode('utf-8'))
         self.dim = (int(w_i),int(h_i))
         self.outputDim = (int(n_o),int(c_o),int(h_o),int(w_o))
@@ -351,7 +351,7 @@ if __name__ == '__main__':
     classifier = annieObjectWrapper(pythonLib, weightsFile)
 
     # check for image val text
-    totalImages = 0;
+    totalImages = 0
     if(imageVal == ''):
         print("\nFlow without Image Validation Text..Creating a file with no ground truths\n")
         imageList = os.listdir(inputImageDir)
@@ -380,7 +380,7 @@ if __name__ == '__main__':
     sys.stdout = orig_stdout
 
     # process images
-    correctTop5 = 0; correctTop1 = 0; wrong = 0; noGroundTruth = 0;
+    correctTop5 = 0; correctTop1 = 0; wrong = 0; noGroundTruth = 0
     for x in range(totalImages):
         imageFileName,grountTruth = imageValidation[x].split(' ')
         groundTruthIndex = int(grountTruth)

--- a/apps/mivisionx_validation_tool/inference_setup.py
+++ b/apps/mivisionx_validation_tool/inference_setup.py
@@ -47,7 +47,7 @@ class annieObjectWrapper():
             output,opName,n_o,c_o,h_o,w_o = output_info.split(',')
         else:
             output,opName,n_o,c_o= output_info.split(',')
-            h_o = '1'; w_o  = '1';
+            h_o = '1'; w_o  = '1'
         self.hdl = self.api.annCreateInference(weightsfile.encode('utf-8'))
         self.dim = (int(w_i),int(h_i))
         self.outputDim = (int(n_o),int(c_o),int(h_o),int(w_o))

--- a/apps/mivisionx_validation_tool/inference_viewer.py
+++ b/apps/mivisionx_validation_tool/inference_viewer.py
@@ -252,8 +252,8 @@ class InferenceViewer(QtWidgets.QMainWindow):
             qOrigImageResized = qOrigImage.scaled(self.image_label.width(), self.image_label.height(), QtCore.Qt.IgnoreAspectRatio)  
             index = self.imgCount % self.frameCount
             self.origImage_layout.itemAt(index).widget().setPixmap(QtGui.QPixmap.fromImage(qOrigImageResized))
-            self.origImage_layout.itemAt(index).widget().setStyleSheet("border: 5px solid yellow;");
-            self.origImage_layout.itemAt(self.lastIndex).widget().setStyleSheet("border: 0");
+            self.origImage_layout.itemAt(index).widget().setStyleSheet("border: 5px solid yellow;")
+            self.origImage_layout.itemAt(self.lastIndex).widget().setStyleSheet("border: 0")
             self.imgCount += 1
             self.lastIndex = index
         

--- a/model_compiler/python/nnir.py
+++ b/model_compiler/python/nnir.py
@@ -123,12 +123,12 @@ class IrAttr(object):
         self.dict_set = []
 
     def set(self,name,value):
-        if not name in self.dict_values:
+        if name not in self.dict_values:
             raise ValueError("Unsupported IR attribute: {}".format(name))
         if type(value) != type(self.dict_values[name]):
             raise ValueError("Invalid IR attribute value type: {} for {}".format(type(value).__name__, name))
         self.dict_values[name] = value
-        if not name in self.dict_set:
+        if name not in self.dict_set:
             self.dict_set.append(name)
 
     def is_set(self,name):
@@ -227,7 +227,7 @@ class IrNode(object):
         }
 
     def set(self,type,inputs,outputs,attr):
-        if not type in self.dict_types or self.dict_types[type] == 0:
+        if type not in self.dict_types or self.dict_types[type] == 0:
             print('ERROR: IrNode.set: operation "%s" not supported' % (type))
             sys.exit(1)
         self.type = type
@@ -307,7 +307,7 @@ class IrGraph(object):
             self.all_F032 = False
         if self.all_F016 == True and tensor.type == 'F032':
             self.all_F016 = False
-        if not tensor.name in self.output_names:
+        if tensor.name not in self.output_names:
             self.locals.append(tensor)
 
     def addNode(self,node):
@@ -873,7 +873,7 @@ class IrGraph(object):
         for name in self.tensor_dict:
             fullTensorList.append(name)
         for name in fullTensorList:
-            if not name in usedTensorList:
+            if name not in usedTensorList:
                 self.removeTensor(name)
 
     def updateBatchSize(self,batchSize):
@@ -1037,7 +1037,7 @@ class IrGraph(object):
                     prevNode = node
                     prevOutput = node.outputs[0]
                 elif node.type == 'copy':
-                    if prevSkipNode != None:
+                    if prevSkipNode is not None:
                         prevSkipNode.outputs[0] = node.outputs[0]
                     else:
                         prevNode.outputs[0] = node.outputs[0]
@@ -1045,7 +1045,7 @@ class IrGraph(object):
                     nodesToRemove.append(node)
                     fusedAnOp = True
                 elif node.type == 'transpose':
-                    if prevSkipNode != None:
+                    if prevSkipNode is not None:
                         prevSkipNode.outputs[0] = node.outputs[0]
                     else:
                         prevNode.outputs[0] = node.outputs[0]
@@ -1124,7 +1124,7 @@ class IrGraph(object):
                     weight = weight * np.repeat(scale, N)
                     self.addBinary(prevNode.inputs[1], weight.view())
                     self.addBinary(prevNode.inputs[2], bias.view())
-                    if prevSkipNode != None:
+                    if prevSkipNode is not None:
                         prevSkipNode.outputs[0] = node.outputs[0]
                     else:
                         prevNode.outputs[0] = node.outputs[0]
@@ -1145,7 +1145,7 @@ class IrGraph(object):
                         leaky_alpha = 0.0
                     prevNode.attr.set('mode', 1)
                     prevNode.attr.set('alpha', leaky_alpha)
-                    if prevSkipNode != None:
+                    if prevSkipNode is not None:
                         prevSkipNode.outputs[0] = node.outputs[0]
                     else:
                         prevNode.outputs[0] = node.outputs[0]

--- a/model_compiler/python/nnir_to_clib.py
+++ b/model_compiler/python/nnir_to_clib.py
@@ -596,7 +596,7 @@ MIVID_API_ENTRY vx_status MIVID_API_CALL mvAddToGraph(vx_graph graph, %s, %s, co
         for tensor in graph.outputs:
             outputList.append(tensor.name)
         for idx, tensor in enumerate(graph.locals):
-            if (not tensor.name in outputList) and (not tensor.name in localList[:idx]):
+            if (tensor.name not in outputList) and (tensor.name not in localList[:idx]):
                 f.write(
                     """    vx_size dims_%s[%d] = { %s };
     vx_tensor %s = vxCreateVirtualTensor(graph, %d, dims_%s, %s, 0);
@@ -927,7 +927,7 @@ MIVID_API_ENTRY vx_status MIVID_API_CALL mvAddToGraph(vx_graph graph, %s, %s, co
     // release local tensors
 """)
         for idx, tensor in enumerate(graph.locals):
-            if (not tensor.name in outputList) and (not tensor.name in localList[:idx]):
+            if (tensor.name not in outputList) and (tensor.name not in localList[:idx]):
                 f.write(
                     """    ERROR_CHECK_STATUS(vxReleaseTensor(&%s));
 """ % (tensor.name))


### PR DESCRIPTION
Fixed linting issues for pep8 conformance.
https://peps.python.org/pep-0008/#programming-recommendations

- Use is not operator rather than not ... is. While both expressions are functionally identical, the former is more readable and preferred
- Instead of != None use is not None
- Remove trailing semicolons