### PR TITLE
MV_DEPLOY:Find Half - Fix

### DIFF
--- a/samples/mv_objdetect/CMakeLists.txt
+++ b/samples/mv_objdetect/CMakeLists.txt
@@ -50,7 +50,7 @@ if (OPENVX_BACKEND_OPENCL_FOUND)
     include_directories (${OpenCL_INCLUDE_DIRS} ${OpenCL_INCLUDE_DIRS}/Headers )
 endif()
 
-include_directories (${ROCM_PATH}/include/mivisionx ${PROJECT_SOURCE_DIR} )
+include_directories (${ROCM_PATH}/include ${ROCM_PATH}/include/mivisionx ${PROJECT_SOURCE_DIR} )
 link_directories    (${ROCM_PATH}/lib ${PROJECT_SOURCE_DIR}/lib)
 option (USE_POSTPROC  "Use postprocessing module implementation" ON)
 set(SOURCES mvobjdetect.cpp mvdeploy_api.cpp visualize.cpp)


### PR DESCRIPTION
Fix
```
make[2]: *** [CMakeFiles/mvobjdetect.dir/build.make:90: CMakeFiles/mvobjdetect.dir/mvdeploy_api.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /long_pathname_so_that_rpms_can_package_the_debug_info/src/extlibs/MIVisionX/samples/mv_objdetect/mvdeploy/mvobjdetect.cpp:27:
/long_pathname_so_that_rpms_can_package_the_debug_info/src/extlibs/MIVisionX/samples/mv_objdetect/mvdeploy/mvdeploy.h:60:10: fatal error: half/half.hpp: No such file or directory
   60 | #include <half/half.hpp>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/mvobjdetect.dir/build.make:76: CMakeFiles/mvobjdetect.dir/mvobjdetect.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:100: CMakeFiles/mvobjdetect.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```