### PR TITLE
Update doc codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,6 @@
-# Documentation files
-docs/* @saadrahim @LisaDelaney @kiritigowda @rrawther
-*.md  @saadrahim @LisaDelaney @kiritigowda @rrawther
-*.rst  @saadrahim @LisaDelaney
-# Header directory
-library/include/*  @saadrahim @LisaDelaney @kiritigowda @rrawther
 # Source code
 * @kiritigowda @rrawther
+# Documentation files
+docs/* @ROCm/rocm-documentation @kiritigowda @rrawther
+*.md @ROCm/rocm-documentation @kiritigowda @rrawther
+*.rst @ROCm/rocm-documentation


### PR DESCRIPTION
Relates to https://github.com/ROCm/ROCm/issues/2833
Set documentation team as codeowners for documentation.
Goal is to make this group of code owners reviewers when merging documentation changes.

