### PR TITLE
NN Inference Setup - Use ONNX 1.12.0

### DIFF
--- a/MIVisionX-setup.py
+++ b/MIVisionX-setup.py
@@ -349,7 +349,7 @@ else:
                 # Install CAFFE Deps
                 os.system('sudo pip3 install google==3.0.0 protobuf==3.12.4')
                 # Install ONNX Deps
-                os.system('sudo pip3 install onnx==1.11.0')
+                os.system('sudo pip3 install onnx==1.12.0')
                 # Install NNEF Deps
                 os.system('mkdir -p '+modelCompilerDeps+'/nnef-deps')
                 os.system(

--- a/model_compiler/README.md
+++ b/model_compiler/README.md
@@ -72,7 +72,7 @@ sudo pip3 install google==3.0.0 protobuf==3.12.4
 * protobuf
 * onnx
 ``` 
-sudo pip3 install protobuf==3.12.4 onnx==1.11.0
+sudo pip3 install protobuf==3.12.4 onnx==1.12.0
 ```
 **Note:** 
 * ONNX Models are available at [ONNX Model Zoo](https://github.com/onnx/models)

--- a/tests/neural_network_tests/runNeuralNetworkTests.py
+++ b/tests/neural_network_tests/runNeuralNetworkTests.py
@@ -279,7 +279,7 @@ if not os.path.exists(modelCompilerDeps):
     # Install CAFFE Deps
     os.system('sudo pip3 install google==3.0.0 protobuf==3.12.4')
     # Install ONNX Deps
-    os.system('sudo pip3 install onnx==1.11.0')
+    os.system('sudo pip3 install onnx==1.12.0')
     # Install NNEF Deps
     os.system('mkdir -p '+modelCompilerDeps+'/nnef-deps')
     os.system(


### PR DESCRIPTION
ONNX 1.11.0 - failure on Ubuntu 22.04 -- Need to upgrade to 1.12.0

```
error: legacy-install-failure
 
× Encountered error while trying to install package.
╰─> onnx
 
note: This is an issue with the package mentioned above, not pip.
hint: See above for output from the failure.
```