### PR TITLE
Fix broken links in 6.1.0 docs

### DIFF
--- a/amd_openvx_extensions/amd_winml/samples/README.md
+++ b/amd_openvx_extensions/amd_winml/samples/README.md
@@ -5,7 +5,7 @@ Get ONNX models from [ONNX Model Zoo](https://github.com/onnx/models)
 ## Sample - SqueezeNet
 
 * Download the [SqueezeNet](https://s3.amazonaws.com/download.onnx/models/opset_8/squeezenet.tar.gz) ONNX Model
-* Use [Netron](https://lutzroeder.github.io/netron/) to open the model.onnx
+* Use [Netron](https://github.com/lutzroeder/netron) to open the model.onnx
 	* Look at Model Properties to find Input & Output Tensor Name (data_0 - input; softmaxout_1 - output)
 	* Look at output tensor dimensions (n,c,h,w  - [1,1000,1,1] for softmaxout_1)
 * Use the label file - [data\Labels.txt](data/Labels.txt) and sample image - data\car.JPEG to run samples
@@ -91,7 +91,7 @@ data labelLocation = scalar:STRING,FULL_PATH_TO\data\Labels.txt
 ## Sample - FER+ Emotion Recognition
 
 * Download the [FER+ Emotion Recognition](https://onnxzoo.blob.core.windows.net/models/opset_8/emotion_ferplus/emotion_ferplus.tar.gz) ONNX Model
-* Use [Netron](https://lutzroeder.github.io/netron/) to open the model.onnx
+* Use [Netron](https://github.com/lutzroeder/netron) to open the model.onnx
 	* Look at Model Properties to find Input & Output Tensor Name (Input3 - input; Plus692_Output_0 - output)
 	* Look at output tensor dimensions (n,c,h,w  - [1,8] for Plus692_Output_0)
 * Use the label file - [data/emotions.txt](data/emotions.txt) to run sample
@@ -121,7 +121,7 @@ data labelLocation = scalar:STRING,FULL_PATH_TO\data\emotions.txt
 ## Sample - VGG19
 
 * Download the [VGG-19](https://s3.amazonaws.com/download.onnx/models/opset_8/vgg19.tar.gz) ONNX Model
-* Use [Netron](https://lutzroeder.github.io/netron/) to open the model.onnx
+* Use [Netron](https://github.com/lutzroeder/netron) to open the model.onnx
 	* Look at Model Properties to find Input & Output Tensor Name (data_0 - input; prob_1 - output)
 	* Look at output tensor dimensions (n,c,h,w  - [1,1000] for prob_1)
 * Use the label file - [data/Labels.txt](data/Labels.txt) to run sample

--- a/apps/README.md
+++ b/apps/README.md
@@ -3,7 +3,7 @@
 MIVisionX has several applications built on top of OpenVX and its modules, it uses AMD optimized libraries to build applications that can be used as prototypes or used as models to develop products.
 
 ## Prerequisites
-* [MIVisionX](https://github.com/ROCm/MIVisionX/README.md#build--install-mivisionx) installed
+* [MIVisionX](https://github.com/ROCm/MIVisionX/blob/release/rocm-rel-6.1/README.md#build--install-mivisionx) installed
 
 ## Bubble Pop
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ Docker is a set of platform as a service (PaaS) products that use OS-level virtu
 
 #### Prerequisites
 * Ubuntu `20.04`/`22.04`
-* [ROCm supported hardware](https://rocm.docs.amd.com/en/latest/release/gpu_os_support.html)
+* [ROCm supported hardware](https://rocm.docs.amd.com/projects/install-on-linux/en/docs-6.1.0/reference/system-requirements.html)
 * Install [ROCm](https://rocmdocs.amd.com/en/latest/deploy/linux/installer/install.html) with `--usecase=graphics,rocm`
 * [Docker](https://docs.docker.com/engine/install/ubuntu/)
 

--- a/utilities/rocAL/rocAL_video_unittests/README.md
+++ b/utilities/rocAL/rocAL_video_unittests/README.md
@@ -92,7 +92,7 @@ Arguments to be modified in testScript.sh to get the following output:
 - STEP=3
 - STRIDE=5
 
-![video_reader.png](./samples/video_reader.png)
+![video_reader.png](samples/video_reader.png)
 
 To test with VideoReaderResize pass reader_case as 2:
 > ./testScript.sh <path_to_video_file/folder> 2
@@ -105,7 +105,7 @@ Also RESIZE_WIDTH and RESIZE_HEIGHT can be changed in testScript.sh
 
 > ./testScript.sh <[path/to/sequence_folder](https://github.com/ROCm/MIVisionX-data/tree/main/rocal_data/video_and_sequence_samples/sequence)> 3 
 
-![sequence_reader.png](./samples/sequence_reader.png)
+![sequence_reader.png](samples/sequence_reader.png)
 
 NOTE :
 
@@ -123,7 +123,7 @@ Arguments to be modified in testScript.sh to enable sequence rearrange:
 
 ENABLE_SEQUENCE_REARRANGE=1
 
-![sequence_rearrange.png](./samples/sequence_rearrange.png)
+![sequence_rearrange.png](samples/sequence_rearrange.png)
 
 New Sequence order : (2, 1, 1, 0), The order can be changed directly in rocAL_video_unittests.cpp file. The values specified in the order can only be in the range [0,sequence_length)
 


### PR DESCRIPTION
This PR fixes broken links in MIVisionX on the ROCm docs portal.