### PR TITLE
Revert "Introduce Audio Layout and fix Spectrogram "

### DIFF
--- a/amd_openvx_extensions/amd_rpp/include/internal_rpp.h
+++ b/amd_openvx_extensions/amd_rpp/include/internal_rpp.h
@@ -68,10 +68,7 @@ enum vxTensorLayout {
     VX_NHWC = 0,
     VX_NCHW = 1,
     VX_NFHWC = 2,
-    VX_NFCHW = 3,
-    VX_NHW = 4,     // Audio/2D layout
-    VX_NFT = 5,     // Frequency major, Used for Spectrogram/MelFilterBank
-    VX_NTF = 6      // Time major, Used for Spectrogram/MelFilterBank
+    VX_NFCHW = 3
 };
 
 //! Brief The utility functions
@@ -79,9 +76,8 @@ vx_node createNode(vx_graph graph, vx_enum kernelEnum, vx_reference params[], vx
 vx_status createRPPHandle(vx_node node, vxRppHandle ** pHandle, Rpp32u batchSize, Rpp32u deviceType);
 vx_status releaseRPPHandle(vx_node node, vxRppHandle * handle, Rpp32u deviceType);
 void fillDescriptionPtrfromDims(RpptDescPtr &descPtr, vxTensorLayout layout, size_t *tensorDims);
-void fillAudioDescriptionPtrFromDims(RpptDescPtr &descPtr, size_t *tensorDims, vxTensorLayout layout = vxTensorLayout::VX_NHW);
+void fillAudioDescriptionPtrFromDims(RpptDescPtr &descPtr, size_t *tensorDims);
 RpptDataType getRpptDataType(vx_enum dataType);
-RpptLayout getRpptLayout(vxTensorLayout layout);
 
 class Kernellist
 {

--- a/amd_openvx_extensions/amd_rpp/source/kernel_rpp.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/kernel_rpp.cpp
@@ -2597,27 +2597,6 @@ RpptDataType getRpptDataType(vx_enum vxDataType) {
     }
 }
 
-RpptLayout getRpptLayout(vxTensorLayout layout) {
-    switch(layout) {
-        case vxTensorLayout::VX_NHWC:
-            return RpptLayout::NHWC;
-        case vxTensorLayout::VX_NCHW:
-            return RpptLayout::NCHW;
-        case vxTensorLayout::VX_NFHWC:
-            return RpptLayout::NHWC;
-        case vxTensorLayout::VX_NFCHW:
-            return RpptLayout::NCHW;
-        case vxTensorLayout::VX_NHW:
-            return RpptLayout::NHW;
-        case vxTensorLayout::VX_NFT:
-            return RpptLayout::NFT;
-        case vxTensorLayout::VX_NTF:
-            return RpptLayout::NTF;
-        default:
-            throw std::runtime_error("Invalid layout");
-    }
-}
-
 void fillDescriptionPtrfromDims(RpptDescPtr &descPtr, vxTensorLayout layout, size_t *tensorDims) {
     switch(layout) {
         case vxTensorLayout::VX_NHWC: {
@@ -2674,7 +2653,7 @@ void fillDescriptionPtrfromDims(RpptDescPtr &descPtr, vxTensorLayout layout, siz
     }
 }
 
-void fillAudioDescriptionPtrFromDims(RpptDescPtr &descPtr, size_t *maxTensorDims, vxTensorLayout layout) {
+void fillAudioDescriptionPtrFromDims(RpptDescPtr &descPtr, size_t *maxTensorDims) {
     descPtr->n = maxTensorDims[0];
     descPtr->h = maxTensorDims[1];
     descPtr->w = maxTensorDims[2];
@@ -2684,7 +2663,6 @@ void fillAudioDescriptionPtrFromDims(RpptDescPtr &descPtr, size_t *maxTensorDims
     descPtr->strides.wStride = descPtr->c;
     descPtr->strides.cStride = 1;
     descPtr->numDims = 4;
-    descPtr->layout = getRpptLayout(layout);
 }
 
 // utility functions


### PR DESCRIPTION
Reverts ROCm/MIVisionX#1347

```
/home/kiriti/develop/mivisionx-kiriti/MIVisionX/amd_openvx_extensions/amd_rpp/source/tensor/Spectrogram.cpp: In function ‘vx_status processSpectrogram(vx_node, _vx_reference* const*, vx_uint32)’:
/home/kiriti/develop/mivisionx-kiriti/MIVisionX/amd_openvx_extensions/amd_rpp/source/tensor/Spectrogram.cpp:138:22: error: ‘rppt_spectrogram_host’ was not declared in this scope; did you mean ‘rppt_spatter_host’?
  138 |         rpp_status = rppt_spectrogram_host(data->pSrc, data->pSrcDesc, data->pDst, data->pDstDesc, data->pSrcLength, data->centerWindows, data->reflectPadding,
      |                      ^~~~~~~~~~~~~~~~~~~~~
      |                      rppt_spatter_host
make[2]: *** [amd_openvx_extensions/amd_rpp/CMakeFiles/vx_rpp.dir/build.make:1532: amd_openvx_extensions/amd_rpp/CMakeFiles/vx_rpp.dir/source/tensor/Spectrogram.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/home/kiriti/develop/mivisionx-kiriti/MIVisionX/amd_openvx_extensions/amd_rpp/source/kernel_rpp.cpp: In function ‘RpptLayout getRpptLayout(vxTensorLayout)’:
/home/kiriti/develop/mivisionx-kiriti/MIVisionX/amd_openvx_extensions/amd_rpp/source/kernel_rpp.cpp:2611:32: error: ‘NHW’ is not a member of ‘RpptLayout’
 2611 |             return RpptLayout::NHW;
      |                                ^~~
/home/kiriti/develop/mivisionx-kiriti/MIVisionX/amd_openvx_extensions/amd_rpp/source/kernel_rpp.cpp:2613:32: error: ‘NFT’ is not a member of ‘RpptLayout’
 2613 |             return RpptLayout::NFT;
      |                                ^~~
/home/kiriti/develop/mivisionx-kiriti/MIVisionX/amd_openvx_extensions/amd_rpp/source/kernel_rpp.cpp:2615:32: error: ‘NTF’ is not a member of ‘RpptLayout’
 2615 |             return RpptLayout::NTF;
      |                                ^~~
make[2]: *** [amd_openvx_extensions/amd_rpp/CMakeFiles/vx_rpp.dir/build.make:1571: amd_openvx_extensions/amd_rpp/CMakeFiles/vx_rpp.dir/source/kernel_rpp.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1402: amd_openvx_extensions/amd_rpp/CMakeFiles/vx_rpp.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 99%] Linking CXX shared library ../../lib/libvx_opencv.so
[ 99%] Built target vx_opencv
make: *** [Makefile:163: all] Error 2
```