### PR TITLE
Update CODEOWNERS for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Source code
 * @kiritigowda @rrawther
 # Documentation files
-docs/* @ROCm/rocm-documentation @kiritigowda @rrawther
+docs/ @ROCm/rocm-documentation @kiritigowda @rrawther
 *.md @ROCm/rocm-documentation @kiritigowda @rrawther
-*.rst @ROCm/rocm-documentation
+*.rst @ROCm/rocm-documentation @kiritigowda @rrawther
+.readthedocs.yaml @ROCm/rocm-documentation @kiritigowda @rrawther


### PR DESCRIPTION
Fixes syntax (docs/* to docs/) and adds doc team as owner for RTD config file