### PR TITLE
ROCm 6.3 - Cherry-pick - NN Dependencies - Bump future package from 0.18.2 to 1.0.0 (#1436)

### DIFF
--- a/MIVisionX-setup.py
+++ b/MIVisionX-setup.py
@@ -282,7 +282,7 @@ if "VERSION_ID=24" in os_info_data:
     pipONNXVersion = "onnx==1.16.0"
     pipProtoVersion= "protobuf==3.20.2"
 pip3InferencePackagesUbuntu = [
-    'future==0.18.2',
+    'future==1.0.0',
     'pytz==2022.1',
     'google==3.0.0',
     str(pipNumpyVersion),

--- a/docs/install/model-compiler-install.rst
+++ b/docs/install/model-compiler-install.rst
@@ -40,7 +40,7 @@ Prerequisites
 
   .. code-block:: shell
     
-      sudo pip3 install future==0.18.2 pytz==2022.1 numpy==1.23.0
+      sudo pip3 install future==1.0.0 pytz==2022.1 numpy==1.23.0
 
 
 .. note::

--- a/model_compiler/README.md
+++ b/model_compiler/README.md
@@ -54,7 +54,7 @@ MIVisionX allows hundreds of different [OpenVX](https://www.khronos.org/registry
   ```
 * PIP3 Packages
   ```
-  sudo pip3 install future==0.18.2 pytz==2022.1 numpy==1.23.0
+  sudo pip3 install future==1.0.0 pytz==2022.1 numpy==1.23.0
   ```
 
 **Note:** MIVisionX installs model compiler scripts at `/opt/rocm/libexec/mivisionx/model_compiler/python/`

--- a/tests/neural_network_tests/runNeuralNetworkTests.py
+++ b/tests/neural_network_tests/runNeuralNetworkTests.py
@@ -252,7 +252,7 @@ if "VERSION_ID=24" in os_info_data:
     pipONNXVersion = "onnx==1.16.0"
     pipProtoVersion= "protobuf==3.20.2"
 pip3InferencePackagesUbuntu = [
-    'future==0.18.2',
+    'future==1.0.0',
     'pytz==2022.1',
     'google==3.0.0',
     str(pipNumpyVersion),


### PR DESCRIPTION
* future version upgrade to 1.0.0

* Revert future version to 0.18.2 for rpm

* Update runNeuralNetworkTests.py

---------