### PR TITLE
AMD Clang Warning Fix

### DIFF
--- a/amd_openvx/openvx/include/VX/vx_compatibility.h
+++ b/amd_openvx/openvx/include/VX/vx_compatibility.h
@@ -160,9 +160,6 @@
 #define VX_THRESHOLD_FALSE_VALUE (VX_ATTRIBUTE_BASE(VX_ID_KHRONOS, VX_TYPE_THRESHOLD) + 0x5)
 #define VX_THRESHOLD_DATA_TYPE (VX_ATTRIBUTE_BASE(VX_ID_KHRONOS, VX_TYPE_THRESHOLD) + 0x6)
 
-#define VX_BIDIRECTIONAL (VX_ENUM_BASE(VX_ID_KHRONOS, VX_ENUM_DIRECTION) + 0x2)
-
-
 typedef vx_status(VX_CALLBACK *vx_kernel_input_validate_f)(vx_node node, vx_uint32 index);
 
 typedef vx_status(VX_CALLBACK *vx_kernel_output_validate_f)(vx_node node, vx_uint32 index, vx_meta_format meta);

--- a/amd_openvx/openvx/include/VX/vx_types.h
+++ b/amd_openvx/openvx/include/VX/vx_types.h
@@ -613,6 +613,8 @@ enum vx_direction_e {
     VX_INPUT = VX_ENUM_BASE(VX_ID_KHRONOS, VX_ENUM_DIRECTION) + 0x0,
     /*! \brief The parameter is an output only. */
     VX_OUTPUT = VX_ENUM_BASE(VX_ID_KHRONOS, VX_ENUM_DIRECTION) + 0x1,
+    /*! \brief The parameter is bidirectional. */
+    VX_BIDIRECTIONAL = VX_ENUM_BASE(VX_ID_KHRONOS, VX_ENUM_DIRECTION) + 0x2
 };
 
 /*! \brief These enumerations are given to the <tt>\ref vxHint</tt> API to enable/disable platform


### PR DESCRIPTION
Moved vx_bidirectional to vx_direction_e structure to fix the warning.

Fixes #1455 