### PR TITLE
Add OpenCL ICD Loader package installation to setup script

### DIFF
--- a/MIVisionX-setup.py
+++ b/MIVisionX-setup.py
@@ -330,6 +330,14 @@ rocdecodeRPMPackages = [
     'rocdecode-devel'
 ]
 
+openclDebianPackages = [
+    'ocl-icd-opencl-dev'
+]
+
+openclRPMPackages = [
+    'ocl-icd-devel'
+]
+
 opencvDebianPackages = [
     'libopencv-dev'
 ]
@@ -588,4 +596,15 @@ else:
         ERROR_CHECK(os.system(
             '(cd '+deps_dir+'/gdb-12.1; ./configure --with-python3; make CXXFLAGS="-static-libstdc++" -j$(nproc); sudo make install)'))
 
+    # Install OpenCL ICD Loader
+    if backend == 'OCL':
+        if "Ubuntu" in platfromInfo:
+            for i in range(len(openclDebianPackages)):
+                ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
+                        ' '+linuxSystemInstall_check+' install -y '+ openclDebianPackages[i]))
+        else:
+            for i in range(len(openclRPMPackages)):
+                ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
+                        ' '+linuxSystemInstall_check+' install -y '+ openclRPMPackages[i]))
+                        
     print("\nMIVisionX Dependencies Installed with MIVisionX-setup.py V-"+__version__+" on "+platfromInfo+"\n")


### PR DESCRIPTION
Since ROCm doesn't package the ICD loader anymore, the distro package needs to be installed to build with OpenCL backend.