### PR TITLE
VX_RPP - Extending Copy Node for all dtypes

### DIFF
--- a/amd_openvx_extensions/amd_rpp/include/internal_rpp.h
+++ b/amd_openvx_extensions/amd_rpp/include/internal_rpp.h
@@ -95,6 +95,7 @@ void fillDescriptionPtrfromDims(RpptDescPtr &descPtr, vxTensorLayout layout, siz
 void fillGenericDescriptionPtrfromDims(RpptGenericDescPtr &genericDescPtr, vxTensorLayout layout, size_t *maxTensorDims);
 void fillAudioDescriptionPtrFromDims(RpptDescPtr &descPtr, size_t *maxTensorDims, vxTensorLayout layout = vxTensorLayout::VX_NHW);
 RpptDataType getRpptDataType(vx_enum dataType);
+size_t getDataTypeSize(vx_enum dataType);
 
 class Kernellist
 {

--- a/amd_openvx_extensions/amd_rpp/source/kernel_rpp.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/kernel_rpp.cpp
@@ -2808,6 +2808,29 @@ RpptDataType getRpptDataType(vx_enum vxDataType) {
     }
 }
 
+size_t getDataTypeSize(vx_enum vxDataType) {
+    switch (vxDataType) {
+#if defined(AMD_FP16_SUPPORT)
+        case vx_type_e::VX_TYPE_FLOAT16:
+            return sizeof(vx_float16);
+#endif
+        case vx_type_e::VX_TYPE_FLOAT32:
+            return sizeof(vx_float32);
+        case vx_type_e::VX_TYPE_INT8:
+            return sizeof(vx_int8);
+        case vx_type_e::VX_TYPE_INT16:
+            return sizeof(vx_int16);
+        case vx_type_e::VX_TYPE_INT32:
+            return sizeof(vx_int32);
+        case vx_type_e::VX_TYPE_UINT8:
+            return sizeof(vx_uint8);
+        case vx_type_e::VX_TYPE_UINT32:
+            return sizeof(vx_uint32);
+        default:
+            throw std::runtime_error("Invalid datatype.");
+    }
+}
+
 void fillDescriptionPtrfromDims(RpptDescPtr &descPtr, vxTensorLayout layout, size_t *tensorDims) {
     switch(layout) {
         case vxTensorLayout::VX_NHWC: {

--- a/amd_openvx_extensions/amd_rpp/source/tensor/Copy.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/tensor/Copy.cpp
@@ -106,15 +106,10 @@ static vx_status VX_CALLBACK initializeCopy(vx_node node, const vx_reference *pa
     for (unsigned i = 0; i < num_of_dims; i++)
         data->tensorSize *= tensor_dims[i];
 
-    if (input_tensor_dtype == vx_type_e::VX_TYPE_FLOAT32 && output_tensor_dtype == vx_type_e::VX_TYPE_FLOAT32) {
-        data->tensorSize *= sizeof(vx_float32);
-    } else if (input_tensor_dtype == vx_type_e::VX_TYPE_FLOAT16 && output_tensor_dtype == vx_type_e::VX_TYPE_FLOAT16) {
-#if defined(AMD_FP16_SUPPORT)
-        data->tensorSize *= sizeof(vx_float16);
-#else
-        data->tensorSize *= sizeof(vx_uint16);
-#endif
-    }
+    if (input_tensor_dtype == output_tensor_dtype)
+        data->tensorSize *= getDataTypeSize(input_tensor_dtype);
+    else
+        return VX_ERROR_NOT_SUPPORTED;
     refreshCopy(node, parameters, num, data);
     STATUS_ERROR_CHECK(vxSetNodeAttribute(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     return VX_SUCCESS;


### PR DESCRIPTION
Existing Copy node only supports f32, f16, u8 and i8. Recently RPP and rocAL introduced support for other integral dtypes so adding changes in Copy node for supporting the new dtypes