### PR TITLE
VX_RPP - Fix merge conflict wrt Log1p

### DIFF
--- a/amd_openvx_extensions/amd_rpp/CMakeLists.txt
+++ b/amd_openvx_extensions/amd_rpp/CMakeLists.txt
@@ -69,6 +69,7 @@ list(APPEND SOURCES
         source/tensor/Hue.cpp
         source/tensor/Jitter.cpp
         source/tensor/LensCorrection.cpp
+        source/tensor/Log1p.cpp
         source/tensor/MelFilterBank.cpp
         source/tensor/Noise.cpp
         source/tensor/NonSilentRegionDetection.cpp


### PR DESCRIPTION
- Include Log1p path in CMakeLists.txt, overwritten due to merge