### PR TITLE
CXX Flag - Use -fPIC for both release and debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,9 +125,10 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 else()
   # -O3 -- Optimize output file
   # -DNDEBUG -- turn off asserts
-  # -fPIC -- Generate position-independent code if possible
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG")
 endif()
+# -fPIC -- Generate position-independent code if possible
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 message("-- ${BoldBlue}MIVisionX Build Type -- ${CMAKE_BUILD_TYPE}${ColourReset}")
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
Position-independent code is generally recommended for both debug and release builds