### PR TITLE
fix lintian warning description-too-long

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,8 +350,8 @@ include(CPack)
 
 cpack_add_component(runtime
                   DISPLAY_NAME "MIVisionX Runtime Package"
-                  DESCRIPTION "AMD MIVisionX is a comprehensive Computer Vision and ML Inference Toolkit. \
-MIVisionX runtime package provides MIVisionX libraries and license.txt")
+                  DESCRIPTION "Computer Vision and ML Inference Toolkit. \
+MIVisionX libraries and license.txt")
 
 cpack_add_component(dev
                   DISPLAY_NAME "MIVisionX Develop Package"


### PR DESCRIPTION
## Motivation

Fix lintinan description-too-long warning caused by description being greater or equal to 80 characters

## Technical Details

shorten description

## Test Plan

recompile and check warning

## Test Result

no warning

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
