### PR TITLE
HIP -  HIP_CHECK for hipLaunchKernelGGL for gated launch

### DIFF
--- a/amd_openvx/openvx/hipvx/arithmetic_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/arithmetic_kernels.cpp
@@ -65,7 +65,8 @@ int HipExec_AbsDiff_U8_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 ds
     hipLaunchKernelGGL(Hip_AbsDiff_U8_U8U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                        (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -113,7 +114,8 @@ int HipExec_AbsDiff_S16_S16S16_Sat(hipStream_t stream, vx_uint32 dstWidth, vx_ui
     hipLaunchKernelGGL(Hip_AbsDiff_S16_S16S16_Sat, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                     dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                     (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar*)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -165,7 +167,8 @@ int HipExec_Add_U8_U8U8_Wrap(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 d
     hipLaunchKernelGGL(Hip_Add_U8_U8U8_Wrap, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -207,7 +210,8 @@ int HipExec_Add_U8_U8U8_Sat(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 ds
     hipLaunchKernelGGL(Hip_Add_U8_U8U8_Sat, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -255,7 +259,8 @@ int HipExec_Add_S16_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHe
     hipLaunchKernelGGL(Hip_Add_S16_U8U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -303,7 +308,8 @@ int HipExec_Add_S16_S16U8_Wrap(hipStream_t stream, vx_uint32 dstWidth, vx_uint32
     hipLaunchKernelGGL(Hip_Add_S16_S16U8_Wrap, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -351,7 +357,8 @@ int HipExec_Add_S16_S16U8_Sat(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 
     hipLaunchKernelGGL(Hip_Add_S16_S16U8_Sat, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -399,7 +406,8 @@ int HipExec_Add_S16_S16S16_Wrap(hipStream_t stream, vx_uint32 dstWidth, vx_uint3
     hipLaunchKernelGGL(Hip_Add_S16_S16S16_Wrap, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -447,7 +455,8 @@ int HipExec_Add_S16_S16S16_Sat(hipStream_t stream, vx_uint32 dstWidth, vx_uint32
     hipLaunchKernelGGL(Hip_Add_S16_S16S16_Sat, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -499,7 +508,8 @@ int HipExec_Sub_U8_U8U8_Wrap(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 d
     hipLaunchKernelGGL(Hip_Sub_U8_U8U8_Wrap, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -541,7 +551,8 @@ int HipExec_Sub_U8_U8U8_Sat(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 ds
     hipLaunchKernelGGL(Hip_Sub_U8_U8U8_Sat, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -589,7 +600,8 @@ int HipExec_Sub_S16_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHe
     hipLaunchKernelGGL(Hip_Sub_S16_U8U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -637,7 +649,8 @@ int HipExec_Sub_S16_S16U8_Wrap(hipStream_t stream, vx_uint32 dstWidth, vx_uint32
     hipLaunchKernelGGL(Hip_Sub_S16_S16U8_Wrap, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -685,7 +698,8 @@ int HipExec_Sub_S16_S16U8_Sat(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 
     hipLaunchKernelGGL(Hip_Sub_S16_S16U8_Sat, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -733,7 +747,8 @@ int HipExec_Sub_S16_U8S16_Wrap(hipStream_t stream, vx_uint32 dstWidth, vx_uint32
     hipLaunchKernelGGL(Hip_Sub_S16_U8S16_Wrap, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -781,7 +796,8 @@ int HipExec_Sub_S16_U8S16_Sat(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 
     hipLaunchKernelGGL(Hip_Sub_S16_U8S16_Sat, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -829,7 +845,8 @@ int HipExec_Sub_S16_S16S16_Wrap(hipStream_t stream, vx_uint32 dstWidth, vx_uint3
     hipLaunchKernelGGL(Hip_Sub_S16_S16S16_Wrap, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -877,7 +894,8 @@ int HipExec_Sub_S16_S16S16_Sat(hipStream_t stream, vx_uint32 dstWidth, vx_uint32
     hipLaunchKernelGGL(Hip_Sub_S16_S16S16_Sat, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -932,7 +950,8 @@ int HipExec_Mul_U8_U8U8_Wrap_Trunc(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -983,7 +1002,8 @@ int HipExec_Mul_U8_U8U8_Wrap_Round(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1037,7 +1057,8 @@ int HipExec_Mul_U8_U8U8_Sat_Trunc(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1091,7 +1112,8 @@ int HipExec_Mul_U8_U8U8_Sat_Round(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1142,7 +1164,8 @@ int HipExec_Mul_S16_U8U8_Wrap_Trunc(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1193,7 +1216,8 @@ int HipExec_Mul_S16_U8U8_Wrap_Round(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1244,7 +1268,8 @@ int HipExec_Mul_S16_U8U8_Sat_Trunc(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1295,7 +1320,8 @@ int HipExec_Mul_S16_U8U8_Sat_Round(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1346,7 +1372,8 @@ int HipExec_Mul_S16_S16U8_Wrap_Trunc(hipStream_t stream, vx_uint32 dstWidth, vx_
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1397,7 +1424,8 @@ int HipExec_Mul_S16_S16U8_Wrap_Round(hipStream_t stream, vx_uint32 dstWidth, vx_
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1457,7 +1485,8 @@ int HipExec_Mul_S16_S16U8_Sat_Trunc(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1508,7 +1537,8 @@ int HipExec_Mul_S16_S16U8_Sat_Round(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1559,7 +1589,8 @@ int HipExec_Mul_S16_S16S16_Wrap_Trunc(hipStream_t stream, vx_uint32 dstWidth, vx
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1610,7 +1641,8 @@ int HipExec_Mul_S16_S16S16_Wrap_Round(hipStream_t stream, vx_uint32 dstWidth, vx
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1661,7 +1693,8 @@ int HipExec_Mul_S16_S16S16_Sat_Trunc(hipStream_t stream, vx_uint32 dstWidth, vx_
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1712,7 +1745,8 @@ int HipExec_Mul_S16_S16S16_Sat_Round(hipStream_t stream, vx_uint32 dstWidth, vx_
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         scale);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1766,7 +1800,8 @@ int HipExec_WeightedAverage_U8_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes,
                         alpha_f4, invAlpha_f4);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1875,7 +1910,8 @@ int HipExec_Magnitude_S16_S16S16(hipStream_t stream, vx_uint32 dstWidth, vx_uint
     hipLaunchKernelGGL(Hip_Magnitude_S16_S16S16, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1973,6 +2009,7 @@ int HipExec_Phase_U8_S16S16(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 ds
     hipLaunchKernelGGL(Hip_Phase_U8_S16S16, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }

--- a/amd_openvx/openvx/hipvx/color_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/color_kernels.cpp
@@ -71,9 +71,9 @@ int HipExec_Lut_U8_U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeigh
 
     hipLaunchKernelGGL(Hip_Lut_U8_U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                       (const uchar *)pHipSrcImage, srcImageStrideInBytes,
-                       lut);
-
+                       (const uchar *)pHipSrcImage, srcImageStrideInBytes, lut);
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -109,7 +109,8 @@ int HipExec_ChannelCopy_U8_U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 
     hipLaunchKernelGGL(Hip_ChannelCopy_U8_U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                        (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -146,7 +147,8 @@ int HipExec_ChannelCopy_U8_U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 
     hipLaunchKernelGGL(Hip_ChannelCopy_U8_U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                        (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -183,7 +185,8 @@ int HipExec_ChannelCopy_U1_U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 
     hipLaunchKernelGGL(Hip_ChannelCopy_U1_U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                        (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -215,7 +218,8 @@ int HipExec_ChannelCopy_U1_U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 
     hipLaunchKernelGGL(Hip_ChannelCopy_U1_U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                        (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -267,7 +271,8 @@ int HipExec_ColorDepth_U8_S16_Wrap(hipStream_t stream, vx_uint32 dstWidth, vx_ui
     hipLaunchKernelGGL(Hip_ColorDepth_U8_S16_Wrap, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, shift);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -318,7 +323,8 @@ int HipExec_ColorDepth_U8_S16_Sat(hipStream_t stream, vx_uint32 dstWidth, vx_uin
     hipLaunchKernelGGL(Hip_ColorDepth_U8_S16_Sat, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, shift);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -364,7 +370,8 @@ int HipExec_ColorDepth_S16_U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 
     hipLaunchKernelGGL(Hip_ColorDepth_S16_U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, shift);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -405,7 +412,8 @@ int HipExec_ChannelExtract_U8_U16_Pos0(hipStream_t stream, vx_uint32 dstWidth, v
     hipLaunchKernelGGL(Hip_ChannelExtract_U8_U16_Pos0, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -442,7 +450,8 @@ int HipExec_ChannelExtract_U8_U16_Pos1(hipStream_t stream, vx_uint32 dstWidth, v
     hipLaunchKernelGGL(Hip_ChannelExtract_U8_U16_Pos1, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -480,7 +489,8 @@ int HipExec_ChannelExtract_U8_U24_Pos0(hipStream_t stream, vx_uint32 dstWidth, v
     hipLaunchKernelGGL(Hip_ChannelExtract_U8_U24_Pos0, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -518,7 +528,8 @@ int HipExec_ChannelExtract_U8_U24_Pos1(hipStream_t stream, vx_uint32 dstWidth, v
     hipLaunchKernelGGL(Hip_ChannelExtract_U8_U24_Pos1, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -556,7 +567,8 @@ int HipExec_ChannelExtract_U8_U24_Pos2(hipStream_t stream, vx_uint32 dstWidth, v
     hipLaunchKernelGGL(Hip_ChannelExtract_U8_U24_Pos2, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -633,7 +645,8 @@ int HipExec_ChannelExtract_U8_U32_Pos0(hipStream_t stream, vx_uint32 dstWidth, v
                             (const uchar *)pHipSrcImage1, srcImage1StrideInBytes,
                             dstWidthComp);
     }
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -710,7 +723,8 @@ int HipExec_ChannelExtract_U8_U32_Pos1(hipStream_t stream, vx_uint32 dstWidth, v
                             (const uchar *)pHipSrcImage1, srcImage1StrideInBytes,
                             dstWidthComp);
     }
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -787,7 +801,8 @@ int HipExec_ChannelExtract_U8_U32_Pos2(hipStream_t stream, vx_uint32 dstWidth, v
                             (const uchar *)pHipSrcImage1, srcImage1StrideInBytes,
                             dstWidthComp);
     }
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 

--- a/amd_openvx/openvx/hipvx/color_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/color_kernels.cpp
@@ -879,7 +879,8 @@ int HipExec_ChannelExtract_U8_U32_Pos3(hipStream_t stream, vx_uint32 dstWidth, v
                             (const uchar *)pHipSrcImage1, srcImage1StrideInBytes,
                             dstWidthComp);
     }
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -923,7 +924,8 @@ int HipExec_ChannelExtract_U8U8U8_U24(hipStream_t stream, vx_uint32 dstWidth, vx
     hipLaunchKernelGGL(Hip_ChannelExtract_U8U8U8_U24, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage1, (uchar *)pHipDstImage2, (uchar *)pHipDstImage3, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -967,7 +969,8 @@ int HipExec_ChannelExtract_U8U8U8_U32(hipStream_t stream, vx_uint32 dstWidth, vx
     hipLaunchKernelGGL(Hip_ChannelExtract_U8U8U8_U32, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage1, (uchar *)pHipDstImage2, (uchar *)pHipDstImage3, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1014,7 +1017,8 @@ int HipExec_ChannelExtract_U8U8U8U8_U32(hipStream_t stream, vx_uint32 dstWidth, 
     hipLaunchKernelGGL(Hip_ChannelExtract_U8U8U8U8_U32, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage1, (uchar *)pHipDstImage2, (uchar *)pHipDstImage3, (uchar *)pHipDstImage4, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1062,7 +1066,8 @@ int HipExec_ChannelCombine_U16_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_u
     hipLaunchKernelGGL(Hip_ChannelCombine_U16_U8U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1112,7 +1117,8 @@ int HipExec_ChannelCombine_U24_U8U8U8_RGB(hipStream_t stream, vx_uint32 dstWidth
     hipLaunchKernelGGL(Hip_ChannelCombine_U24_U8U8U8_RGB, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes, (const uchar *)pHipSrcImage3, srcImage3StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1162,7 +1168,8 @@ int HipExec_ChannelCombine_U32_U8U8U8_UYVY(hipStream_t stream, vx_uint32 dstWidt
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes, (const uchar *)pHipSrcImage3, srcImage3StrideInBytes,
                         dstWidthComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1212,7 +1219,8 @@ int HipExec_ChannelCombine_U32_U8U8U8_YUYV(hipStream_t stream, vx_uint32 dstWidt
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes, (const uchar *)pHipSrcImage3, srcImage3StrideInBytes,
                         dstWidthComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1268,7 +1276,8 @@ int HipExec_ChannelCombine_U32_U8U8U8U8_RGBX(hipStream_t stream, vx_uint32 dstWi
     hipLaunchKernelGGL(Hip_ChannelCombine_U32_U8U8U8U8_RGBX, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes, (const uchar *)pHipSrcImage3, srcImage3StrideInBytes, (const uchar *)pHipSrcImage4, srcImage4StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1320,7 +1329,8 @@ int HipExec_ColorConvert_RGB_RGBX(hipStream_t stream, vx_uint32 dstWidth, vx_uin
     hipLaunchKernelGGL(Hip_ColorConvert_RGB_RGBX, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage1, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 __global__ void __attribute__((visibility("default")))
@@ -1554,7 +1564,8 @@ int HipExec_ColorConvert_RGB_UYVY(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes, dstImageStrideInBytesComp,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageStrideInBytesComp,
                         dstWidthComp, dstHeightComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1790,7 +1801,8 @@ int HipExec_ColorConvert_RGB_YUYV(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes, dstImageStrideInBytesComp,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageStrideInBytesComp,
                         dstWidthComp, dstHeightComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1840,7 +1852,8 @@ int HipExec_ColorConvert_RGBX_RGB(hipStream_t stream, vx_uint32 dstWidth, vx_uin
     hipLaunchKernelGGL(Hip_ColorConvert_RGBX_RGB, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage1, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -2085,7 +2098,8 @@ int HipExec_ColorConvert_RGBX_UYVY(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes, dstImageStrideInBytesComp,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageStrideInBytesComp,
                         dstWidthComp, dstHeightComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -2330,7 +2344,8 @@ int HipExec_ColorConvert_RGBX_YUYV(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes, dstImageStrideInBytesComp,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageStrideInBytesComp,
                         dstWidthComp, dstHeightComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -2595,7 +2610,8 @@ int HipExec_ColorConvert_RGB_IYUV(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes, dstImageStrideInBytesComp,
                         (const uchar *)pHipSrcYImage, srcYImageStrideInBytes, (const uchar *)pHipSrcUImage, srcUImageStrideInBytes, (const uchar *)pHipSrcVImage, srcVImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcYImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -2850,7 +2866,8 @@ int HipExec_ColorConvert_RGB_NV12(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes, dstImageStrideInBytesComp,
                         (const uchar *)pHipSrcLumaImage, srcLumaImageStrideInBytes, (const uchar *)pHipSrcChromaImage, srcChromaImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcLumaImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -3105,7 +3122,8 @@ int HipExec_ColorConvert_RGB_NV21(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes, dstImageStrideInBytesComp,
                         (const uchar *)pHipSrcLumaImage, srcLumaImageStrideInBytes, (const uchar *)pHipSrcChromaImage, srcChromaImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcLumaImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -3379,7 +3397,8 @@ int HipExec_ColorConvert_RGBX_IYUV(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes, dstImageStrideInBytesComp,
                         (const uchar *)pHipSrcYImage, srcYImageStrideInBytes, (const uchar *)pHipSrcUImage, srcUImageStrideInBytes, (const uchar *)pHipSrcVImage, srcVImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcYImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -3643,7 +3662,8 @@ int HipExec_ColorConvert_RGBX_NV12(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes, dstImageStrideInBytesComp,
                         (const uchar *)pHipSrcLumaImage, srcLumaImageStrideInBytes, (const uchar *)pHipSrcChromaImage, srcChromaImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcLumaImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -3907,7 +3927,8 @@ int HipExec_ColorConvert_RGBX_NV21(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes, dstImageStrideInBytesComp,
                         (const uchar *)pHipSrcLumaImage, srcLumaImageStrideInBytes, (const uchar *)pHipSrcChromaImage, srcChromaImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcLumaImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4040,7 +4061,8 @@ int HipExec_ColorConvert_IYUV_RGB(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstYImage, dstYImageStrideInBytes, (uchar *)pHipDstUImage, dstUImageStrideInBytes, (uchar *)pHipDstVImage, dstVImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcImageStrideInBytesComp, dstYImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4167,7 +4189,8 @@ int HipExec_ColorConvert_IYUV_RGBX(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstYImage, dstYImageStrideInBytes, (uchar *)pHipDstUImage, dstUImageStrideInBytes, (uchar *)pHipDstVImage, dstVImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcImageStrideInBytesComp, dstYImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4229,7 +4252,8 @@ int HipExec_FormatConvert_IYUV_UYVY(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstYImage, dstYImageStrideInBytes, (uchar *)pHipDstUImage, dstUImageStrideInBytes, (uchar *)pHipDstVImage, dstVImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcImageStrideInBytesComp, dstYImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4291,7 +4315,8 @@ int HipExec_FormatConvert_IYUV_YUYV(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstYImage, dstYImageStrideInBytes, (uchar *)pHipDstUImage, dstUImageStrideInBytes, (uchar *)pHipDstVImage, dstVImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcImageStrideInBytesComp, dstYImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4433,7 +4458,8 @@ int HipExec_ColorConvert_NV12_RGB(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImageLuma, dstImageLumaStrideInBytes, (uchar *)pHipDstImageChroma, dstImageChromaStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcImageStrideInBytesComp, dstImageLumaStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4569,7 +4595,8 @@ int HipExec_ColorConvert_NV12_RGBX(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImageLuma, dstImageLumaStrideInBytes, (uchar *)pHipDstImageChroma, dstImageChromaStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcImageStrideInBytesComp, dstImageLumaStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4627,7 +4654,8 @@ int HipExec_FormatConvert_NV12_UYVY(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImageLuma, dstImageLumaStrideInBytes, (uchar *)pHipDstImageChroma, dstImageChromaStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcImageStrideInBytesComp, dstImageLumaStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4685,7 +4713,8 @@ int HipExec_FormatConvert_NV12_YUYV(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImageLuma, dstImageLumaStrideInBytes, (uchar *)pHipDstImageChroma, dstImageChromaStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcImageStrideInBytesComp, dstImageLumaStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4767,7 +4796,8 @@ int HipExec_ColorConvert_YUV4_RGB(hipStream_t stream, vx_uint32 dstWidth, vx_uin
     hipLaunchKernelGGL(Hip_ColorConvert_YUV4_RGB, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstYImage, dstYImageStrideInBytes, (uchar *)pHipDstUImage, dstUImageStrideInBytes, (uchar *)pHipDstVImage, dstVImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4843,7 +4873,8 @@ int HipExec_ColorConvert_YUV4_RGBX(hipStream_t stream, vx_uint32 dstWidth, vx_ui
     hipLaunchKernelGGL(Hip_ColorConvert_YUV4_RGBX, dim3(ceil((float)globalThreads_x / localThreads_x), ceil((float)globalThreads_y / localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstYImage, dstYImageStrideInBytes, (uchar *)pHipDstUImage, dstUImageStrideInBytes, (uchar *)pHipDstVImage, dstVImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4908,7 +4939,8 @@ int HipExec_FormatConvert_IUV_UV12(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstUImage, dstUImageStrideInBytes, (uchar *)pHipDstVImage, dstVImageStrideInBytes,
                         (const uchar *)pHipSrcChromaImage, srcChromaImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcChromaImageStrideInBytesComp, dstUImageStrideInBytesComp, dstVImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4967,7 +4999,8 @@ int HipExec_FormatConvert_UV12_IUV(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstChromaImage, dstChromaImageStrideInBytes,
                         (const uchar *)pHipSrcUImage, srcUImageStrideInBytes, (const uchar *)pHipSrcVImage, srcVImageStrideInBytes,
                         dstWidthComp, dstHeightComp, srcUImageStrideInBytesComp, srcVImageStrideInBytesComp, dstChromaImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -5019,7 +5052,8 @@ int HipExec_FormatConvert_UV_UV12(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstUImage, dstUImageStrideInBytes, (uchar *)pHipDstVImage, dstVImageStrideInBytes,
                         (const uchar *)pHipSrcChromaImage, srcChromaImageStrideInBytes,
                         dstWidthComp, dstHeightComp, dstUImageStrideInBytesComp, dstVImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -5063,6 +5097,7 @@ int HipExec_ScaleUp2x2_U8_U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 d
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp, dstHeightComp, dstImageStrideInBytesComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }

--- a/amd_openvx/openvx/hipvx/filter_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/filter_kernels.cpp
@@ -6418,7 +6418,8 @@ int HipExec_Convolve_S16_U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 ds
     } else {
         return VX_ERROR_NOT_IMPLEMENTED;
     }
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -6578,7 +6579,8 @@ int HipExec_Sobel_S16_U8_3x3_GX(hipStream_t stream, vx_uint32 dstWidth, vx_uint3
     hipLaunchKernelGGL(Hip_Sobel_S16_U8_3x3_GX, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -6722,7 +6724,8 @@ int HipExec_Sobel_S16_U8_3x3_GY(hipStream_t stream, vx_uint32 dstWidth, vx_uint3
     hipLaunchKernelGGL(Hip_Sobel_S16_U8_3x3_GY, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -6941,7 +6944,8 @@ int HipExec_Sobel_S16S16_U8_3x3_GXY(hipStream_t stream, vx_uint32 dstWidth, vx_u
     hipLaunchKernelGGL(Hip_Sobel_S16S16_U8_3x3_GXY, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage1, dstImage1StrideInBytes, (uchar *)pHipDstImage2, dstImage2StrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -7055,7 +7059,8 @@ int HipExec_ScaleGaussianHalf_U8_U8_3x3(hipStream_t stream, vx_uint32 dstWidth, 
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         srcWidth, srcHeight, (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -7309,6 +7314,7 @@ int HipExec_ScaleGaussianHalf_U8_U8_5x5(hipStream_t stream, vx_uint32 dstWidth, 
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         srcWidth, srcHeight, (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         dstWidthComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }

--- a/amd_openvx/openvx/hipvx/filter_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/filter_kernels.cpp
@@ -206,7 +206,8 @@ int HipExec_Box_U8_U8_3x3(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstH
     hipLaunchKernelGGL(Hip_Box_U8_U8_3x3, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -351,7 +352,8 @@ int HipExec_Dilate_U8_U8_3x3(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 d
     hipLaunchKernelGGL(Hip_Dilate_U8_U8_3x3, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -496,7 +498,8 @@ int HipExec_Erode_U8_U8_3x3(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 ds
     hipLaunchKernelGGL(Hip_Erode_U8_U8_3x3, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -759,7 +762,8 @@ int HipExec_Median_U8_U8_3x3(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 d
     hipLaunchKernelGGL(Hip_Median_U8_U8_3x3, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -946,7 +950,8 @@ int HipExec_Gaussian_U8_U8_3x3(hipStream_t stream, vx_uint32 dstWidth, vx_uint32
     hipLaunchKernelGGL(Hip_Gaussian_U8_U8_3x3, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -3673,7 +3678,8 @@ int HipExec_Convolve_U8_U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dst
     } else {
         return VX_ERROR_NOT_IMPLEMENTED;
     }
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 

--- a/amd_openvx/openvx/hipvx/geometric_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/geometric_kernels.cpp
@@ -88,7 +88,8 @@ int HipExec_ScaleImage_U8_U8_Nearest(hipStream_t stream, vx_uint32 dstWidth, vx_
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         xscale, yscale, xoffset, yoffset);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -174,7 +175,8 @@ int HipExec_ScaleImage_U8_U8_Bilinear(hipStream_t stream, vx_uint32 dstWidth, vx
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         xscale, yscale, xoffset, yoffset);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -315,7 +317,8 @@ int HipExec_ScaleImage_U8_U8_Bilinear_Replicate(hipStream_t stream, vx_uint32 ds
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcWidth, srcHeight,
                         xscale, yscale, xoffset, yoffset);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -444,7 +447,8 @@ int HipExec_ScaleImage_U8_U8_Bilinear_Constant(hipStream_t stream, vx_uint32 dst
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcWidth, srcHeight,
                         xscale, yscale, xoffset, yoffset, borderValue);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -755,7 +759,8 @@ int HipExec_ScaleImage_U8_U8_Area(hipStream_t stream, vx_uint32 dstWidth, vx_uin
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         Nx, Ny, iSxSy);
     }
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -843,7 +848,8 @@ int HipExec_WarpAffine_U8_U8_Nearest(hipStream_t stream, vx_uint32 dstWidth, vx_
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (d_affine_matrix_t *) affineMatrix);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -991,7 +997,8 @@ int HipExec_WarpAffine_U8_U8_Nearest_Constant(hipStream_t stream, vx_uint32 dstW
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         (d_affine_matrix_t *) affineMatrix, (uint) borderValue, rect_valid);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1063,7 +1070,8 @@ int HipExec_WarpAffine_U8_U8_Bilinear(hipStream_t stream, vx_uint32 dstWidth, vx
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (d_affine_matrix_t *) affineMatrix);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1135,7 +1143,8 @@ int HipExec_WarpAffine_U8_U8_Bilinear_Constant(hipStream_t stream, vx_uint32 dst
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         (d_affine_matrix_t *) affineMatrix, (uint) borderValue);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1240,7 +1249,8 @@ int HipExec_WarpPerspective_U8_U8_Nearest(hipStream_t stream, vx_uint32 dstWidth
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (d_perspective_matrix_t *) perspectiveMatrix);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1401,7 +1411,8 @@ int HipExec_WarpPerspective_U8_U8_Nearest_Constant(hipStream_t stream, vx_uint32
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         srcWidth, srcHeight, (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         (d_perspective_matrix_t *) perspectiveMatrix, (uint) borderValue);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1491,7 +1502,8 @@ int HipExec_WarpPerspective_U8_U8_Bilinear(hipStream_t stream, vx_uint32 dstWidt
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (d_perspective_matrix_t *) perspectiveMatrix);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1581,7 +1593,8 @@ int HipExec_WarpPerspective_U8_U8_Bilinear_Constant(hipStream_t stream, vx_uint3
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         srcWidth, srcHeight, (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         (d_perspective_matrix_t *) perspectiveMatrixLoc, (uint) borderValue);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1688,7 +1701,8 @@ int HipExec_Remap_U8_U8_Nearest(hipStream_t stream, vx_uint32 dstWidth, vx_uint3
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (uchar *) remap, remapStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1833,7 +1847,8 @@ int HipExec_Remap_U8_U8_Nearest_Constant(hipStream_t stream, vx_uint32 dstWidth,
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         srcWidth, srcHeight, (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (uchar *) remap, remapStrideInBytes, (uint) borderValue);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1893,7 +1908,8 @@ int HipExec_Remap_U8_U8_Bilinear(hipStream_t stream, vx_uint32 dstWidth, vx_uint
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (uchar *) remap, remapStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1953,6 +1969,7 @@ int HipExec_Remap_U8_U8_Bilinear_Constant(hipStream_t stream, vx_uint32 dstWidth
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
                         srcWidth, srcHeight, (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         (uchar *) remap, remapStrideInBytes, (uint) borderValue);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }

--- a/amd_openvx/openvx/hipvx/hip_common_funcs.h
+++ b/amd_openvx/openvx/hipvx/hip_common_funcs.h
@@ -26,6 +26,14 @@ THE SOFTWARE.
 
 #include "hip/hip_runtime.h"
 
+#define HIP_CHECK(command) { \
+    hipError_t status = command; \
+    if (status != hipSuccess) { \
+        std::cerr << "Error: HIP reports " << hipGetErrorString(status) << std::endl; \
+        std::abort(); \
+    } \
+}
+
 #define MASK_EARLY_EXIT 4369
 #define HIPSELECT(a, b, c)  (c ? b : a)
 

--- a/amd_openvx/openvx/hipvx/hip_common_funcs.h
+++ b/amd_openvx/openvx/hipvx/hip_common_funcs.h
@@ -24,6 +24,7 @@ THE SOFTWARE.
 #ifndef MIVISIONX_HIP_COMMON_FUNCS_H
 #define MIVISIONX_HIP_COMMON_FUNCS_H
 
+#include <iostream>
 #include "hip/hip_runtime.h"
 
 #define HIP_CHECK(command) { \

--- a/amd_openvx/openvx/hipvx/logical_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/logical_kernels.cpp
@@ -61,7 +61,8 @@ int HipExec_And_U8_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_And_U8_U8U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -103,7 +104,8 @@ int HipExec_And_U8_U8U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_And_U8_U8U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -145,7 +147,8 @@ int HipExec_And_U8_U1U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_And_U8_U1U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -188,7 +191,8 @@ int HipExec_And_U8_U1U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_And_U8_U1U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -230,7 +234,8 @@ int HipExec_And_U1_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_And_U1_U8U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -272,7 +277,8 @@ int HipExec_And_U1_U8U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_And_U1_U8U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -314,7 +320,8 @@ int HipExec_And_U1_U1U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_And_U1_U1U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -352,7 +359,8 @@ int HipExec_And_U1_U1U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_And_U1_U1U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -394,7 +402,8 @@ int HipExec_Or_U8_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeig
     hipLaunchKernelGGL(Hip_Or_U8_U8U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -436,7 +445,8 @@ int HipExec_Or_U8_U8U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeig
     hipLaunchKernelGGL(Hip_Or_U8_U8U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -478,7 +488,8 @@ int HipExec_Or_U8_U1U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeig
     hipLaunchKernelGGL(Hip_Or_U8_U1U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -521,7 +532,8 @@ int HipExec_Or_U8_U1U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeig
     hipLaunchKernelGGL(Hip_Or_U8_U1U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -563,7 +575,8 @@ int HipExec_Or_U1_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeig
     hipLaunchKernelGGL(Hip_Or_U1_U8U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -605,7 +618,8 @@ int HipExec_Or_U1_U8U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeig
     hipLaunchKernelGGL(Hip_Or_U1_U8U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -647,7 +661,8 @@ int HipExec_Or_U1_U1U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeig
     hipLaunchKernelGGL(Hip_Or_U1_U1U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -685,7 +700,8 @@ int HipExec_Or_U1_U1U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeig
     hipLaunchKernelGGL(Hip_Or_U1_U1U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -727,7 +743,8 @@ int HipExec_Xor_U8_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_Xor_U8_U8U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -769,7 +786,8 @@ int HipExec_Xor_U8_U8U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_Xor_U8_U8U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -811,7 +829,8 @@ int HipExec_Xor_U8_U1U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_Xor_U8_U1U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -854,7 +873,8 @@ int HipExec_Xor_U8_U1U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_Xor_U8_U1U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -896,7 +916,8 @@ int HipExec_Xor_U1_U8U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_Xor_U1_U8U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -980,7 +1001,8 @@ int HipExec_Xor_U1_U1U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_Xor_U1_U1U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1018,7 +1040,8 @@ int HipExec_Xor_U1_U1U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHei
     hipLaunchKernelGGL(Hip_Xor_U1_U1U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes, (const uchar *)pHipSrcImage2, srcImage2StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1055,7 +1078,8 @@ int HipExec_Not_U8_U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeigh
     hipLaunchKernelGGL(Hip_Not_U8_U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1093,7 +1117,8 @@ int HipExec_Not_U8_U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeigh
     hipLaunchKernelGGL(Hip_Not_U8_U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1131,7 +1156,8 @@ int HipExec_Not_U1_U8(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeigh
     hipLaunchKernelGGL(Hip_Not_U1_U8, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1168,6 +1194,7 @@ int HipExec_Not_U1_U1(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeigh
     hipLaunchKernelGGL(Hip_Not_U1_U1, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage1, srcImage1StrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }

--- a/amd_openvx/openvx/hipvx/statistical_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/statistical_kernels.cpp
@@ -65,9 +65,9 @@ int HipExec_Threshold_U8_U8_Binary(hipStream_t stream, vx_uint32 dstWidth, vx_ui
 
     hipLaunchKernelGGL(Hip_Threshold_U8_U8_Binary, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                       (const uchar *)pHipSrcImage, srcImageStrideInBytes,
-                       thresholdValue);
-
+                       (const uchar *)pHipSrcImage, srcImageStrideInBytes, thresholdValue);
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -112,9 +112,9 @@ int HipExec_Threshold_U8_U8_Range(hipStream_t stream, vx_uint32 dstWidth, vx_uin
 
     hipLaunchKernelGGL(Hip_Threshold_U8_U8_Range, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                       (const uchar *)pHipSrcImage, srcImageStrideInBytes,
-                       thresholdLower, thresholdUpper);
-
+                       (const uchar *)pHipSrcImage, srcImageStrideInBytes, thresholdLower, thresholdUpper);
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -154,9 +154,9 @@ int HipExec_Threshold_U1_U8_Binary(hipStream_t stream, vx_uint32 dstWidth, vx_ui
 
     hipLaunchKernelGGL(Hip_Threshold_U1_U8_Binary, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                       (const uchar *)pHipSrcImage, srcImageStrideInBytes,
-                       thresholdValue);
-
+                       (const uchar *)pHipSrcImage, srcImageStrideInBytes, thresholdValue);
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -201,9 +201,9 @@ int HipExec_Threshold_U1_U8_Range(hipStream_t stream, vx_uint32 dstWidth, vx_uin
 
     hipLaunchKernelGGL(Hip_Threshold_U1_U8_Range, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                       (const uchar *)pHipSrcImage, srcImageStrideInBytes,
-                       thresholdLower, thresholdUpper);
-
+                       (const uchar *)pHipSrcImage, srcImageStrideInBytes, thresholdLower, thresholdUpper);
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -258,9 +258,9 @@ int HipExec_Threshold_U8_S16_Binary(hipStream_t stream, vx_uint32 dstWidth, vx_u
 
     hipLaunchKernelGGL(Hip_Threshold_U8_S16_Binary, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                       (const uchar *)pHipSrcImage, srcImageStrideInBytes,
-                       (uint)thresholdValue);
-
+                       (const uchar *)pHipSrcImage, srcImageStrideInBytes, (uint)thresholdValue);
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -316,8 +316,8 @@ int HipExec_Threshold_U8_S16_Range(hipStream_t stream, vx_uint32 dstWidth, vx_ui
 
     hipLaunchKernelGGL(Hip_Threshold_U8_S16_Range, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                        dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                       (const uchar *)pHipSrcImage, srcImageStrideInBytes,
-                       (int)thresholdLower, (int)thresholdUpper);
-
+                       (const uchar *)pHipSrcImage, srcImageStrideInBytes, (int)thresholdLower, (int)thresholdUpper);
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }

--- a/amd_openvx/openvx/hipvx/vision_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/vision_kernels.cpp
@@ -249,7 +249,8 @@ int HipExec_CannySobel_U16_U8_3x3_L1NORM(hipStream_t stream, vx_uint32 dstWidth,
     hipLaunchKernelGGL(Hip_CannySobel_U16_U8_3x3_L1NORM, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -741,7 +742,8 @@ int HipExec_CannySobel_U16_U8_5x5_L1NORM(hipStream_t stream, vx_uint32 dstWidth,
     hipLaunchKernelGGL(Hip_CannySobel_U16_U8_5x5_L1NORM, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1628,7 +1630,8 @@ int HipExec_CannySobel_U16_U8_7x7_L1NORM(hipStream_t stream, vx_uint32 dstWidth,
     hipLaunchKernelGGL(Hip_CannySobel_U16_U8_7x7_L1NORM, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -1853,7 +1856,8 @@ int HipExec_CannySobel_U16_U8_3x3_L2NORM(hipStream_t stream, vx_uint32 dstWidth,
     hipLaunchKernelGGL(Hip_CannySobel_U16_U8_3x3_L2NORM, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -2343,7 +2347,8 @@ int HipExec_CannySobel_U16_U8_5x5_L2NORM(hipStream_t stream, vx_uint32 dstWidth,
     hipLaunchKernelGGL(Hip_CannySobel_U16_U8_5x5_L2NORM, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -3229,7 +3234,8 @@ int HipExec_CannySobel_U16_U8_7x7_L2NORM(hipStream_t stream, vx_uint32 dstWidth,
     hipLaunchKernelGGL(Hip_CannySobel_U16_U8_7x7_L2NORM, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -3398,7 +3404,8 @@ int HipExec_CannySuppThreshold_U8XY_U16_3x3(hipStream_t stream,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         (const uchar *)xyStack, xyStackOffset, capacityOfXY, hyst,
                         dstWidthComp);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -3507,7 +3514,8 @@ int HipExec_FastCorners_XY_U8_NoSupression(hipStream_t stream, vx_uint32 capacit
                         dim3(localThreads_x, localThreads_y), 0, stream, capacityOfDstCorner, (char *) pDstCorner, cornerBufferOffset,
                         srcWidth, srcHeight, (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         strength_threshold);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -3693,7 +3701,8 @@ int HipExec_FastCorners_XY_U8_Supression(hipStream_t stream, vx_uint32 capacityO
                         dim3(localThreads_x, localThreads_y), 0, stream, capacityOfDstCorner, (char *) pDstCorner, cornerBufferOffset,
                         srcWidth, srcHeight, (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         strength_threshold);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -3915,7 +3924,8 @@ int HipExec_HarrisSobel_HG3_U8_3x3(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstGxy, dstGxyStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp1, dstWidthComp2);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -4393,8 +4403,8 @@ int HipExec_HarrisSobel_HG3_U8_5x5(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstGxy, dstGxyStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp1, dstWidthComp2);
-
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -5268,7 +5278,8 @@ int HipExec_HarrisSobel_HG3_U8_7x7(hipStream_t stream, vx_uint32 dstWidth, vx_ui
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstGxy, dstGxyStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes,
                         dstWidthComp1, dstWidthComp2);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -5541,7 +5552,8 @@ int HipExec_HarrisScore_HVC_HG3_3x3(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstVc, dstVcStrideInBytes,
                         (uchar *)pHipSrcGxy, srcGxyStrideInBytes, sensitivity, strength_threshold, border, normFactor,
                         dstWidthComp1, dstWidthComp2);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }
 
@@ -5877,7 +5889,8 @@ int HipExec_HarrisScore_HVC_HG3_5x5(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstVc, dstVcStrideInBytes,
                         (uchar *)pHipSrcGxy, srcGxyStrideInBytes, srcImageBufferSize, sensitivity, strength_threshold, border, normFactor,
                         dstWidthComp1, dstWidthComp2);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 
 }
@@ -6279,7 +6292,8 @@ int HipExec_HarrisScore_HVC_HG3_7x7(hipStream_t stream, vx_uint32 dstWidth, vx_u
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstVc, dstVcStrideInBytes,
                         (uchar *)pHipSrcGxy, srcGxyStrideInBytes, sensitivity, strength_threshold, border, normFactor,
                         dstWidthComp1, dstWidthComp2);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 
 }
@@ -6366,6 +6380,7 @@ int HipExec_NonMaxSupp_XY_ANY_3x3(hipStream_t stream, vx_uint32 capacityOfList, 
                         dim3(localThreads_x, localThreads_y), 0, stream, (char *)pHipDstList, dstListOffset, capacityOfList,
                         srcWidth, srcHeight, (uchar *)pHipSrcImage, srcImageStrideInBytes,
                         srcWidthComp1, srcWidthComp2);
-
+    HIP_CHECK(hipGetLastError()); // Check for launch error
+    HIP_CHECK(hipDeviceSynchronize()); // Check for execution error
     return VX_SUCCESS;
 }


### PR DESCRIPTION
## Motivation

This PR adds HIP_CHECK for robust error handling for hipLaunchKernelGGL and resolves issue #1437

## Technical Details

hipLaunchKernelGGL call unchecked will return failures which are not captured and returns a success for HIP kernels. This PR fixes the issue

## Test Plan

ALL CTests and conformance can run for this PR

## Test Result

ALL conformance for HIP Backend should pass

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
