### PR TITLE
removing SP6

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Review all notable [changes](CHANGELOG.md#changelog) with the latest release
 * Linux distribution
   + Ubuntu - `22.04` / `24.04`
   + RHEL - `8` / `9`
-  + SLES - `15 SP6` / `15 SP7`
+  + SLES - `15 SP7`
 * ROCm: `7.0.0`
 * RPP - `2.0.0`
 * miopen-hip - `3.4.0`

--- a/docs/install/MIVisionX-prerequisites.rst
+++ b/docs/install/MIVisionX-prerequisites.rst
@@ -18,7 +18,7 @@ MIVisionX has been tested on the following Linux environments:
   
 * Ubuntu 22.04 or 24.04
 * RHEL 8 or 9
-* SLES 15 SP6 and SP7
+* SLES 15 SP7
 
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 


### PR DESCRIPTION
## Motivation

SLES SP6 is no longer supported in rocm 7.0
