### PR TITLE
CP - Remove Meta Package dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,12 +236,12 @@ if(DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
 endif()
 
 # Set the dependent packages
-set(MIVISIONX_RUNTIME_PACKAGE_LIST  "rocm-hip-runtime, openmp-extras-runtime, rpp, rocblas, miopen-hip, migraphx")
+set(MIVISIONX_RUNTIME_PACKAGE_LIST  "hip-runtime-amd, openmp-extras-runtime, rpp, rocblas, miopen-hip, migraphx")
 
 # Set the dev dependent packages
-set(MIVISIONX_DEBIAN_DEV_PACKAGE_LIST  "half, rocm-hip-runtime-dev, openmp-extras-dev, rpp-dev, rocblas-dev, miopen-hip-dev, migraphx-dev, pkg-config, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev, libopencv-dev")
+set(MIVISIONX_DEBIAN_DEV_PACKAGE_LIST  "half, hip-dev, openmp-extras-dev, rpp-dev, rocblas-dev, miopen-hip-dev, migraphx-dev, pkg-config, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev, libopencv-dev")
 # TBD - Some RPM packages need Fusion Packages - libavcodec-devel, libavformat-devel, libavutil-devel, libswscale-devel, libopencv
-set(MIVISIONX_RPM_DEV_PACKAGE_LIST  "half, rocm-hip-runtime-devel, openmp-extras-devel, rpp-devel, rocblas-devel, miopen-hip-devel, migraphx-devel, pkg-config")
+set(MIVISIONX_RPM_DEV_PACKAGE_LIST  "half, hip-devel, openmp-extras-devel, rpp-devel, rocblas-devel, miopen-hip-devel, migraphx-devel, pkg-config")
 
 # Add OS specific dependencies
 if(EXISTS "/etc/os-release")

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ MIVisionX toolkit provides tools for accomplishing your tasks throughout the who
   ```
 * HIP
   ```shell
-  sudo apt install rocm-hip-runtime-dev
+  sudo apt install hip-dev
   ```
 * OpenMP
   ```shell


### PR DESCRIPTION
## Motivation

To remove Meta Package Dependency for MiVisionX (to meta package rocm-hip-runtime)
Cherry Pick of https://github.com/ROCm/MIVisionX/pull/1554 to Release

## Technical Details

Dependency to be updated to the level of individual packages

## Test Plan

Verify Build, Package Dependencies

## Test Result
https://compute-artifactory.amd.com/artifactory/list/rocm-osdb-22.04-deb/compute-rocm-dkms-component-baas-1906/
https://compute-artifactory.amd.com/artifactory/list/rocm-osdb-22.04-deb/compute-rocm-dkms-component-baas-1961/
Mainline-16741

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
