### PR TITLE
Replaced links to master branch with develop branch

### DIFF
--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -943,7 +943,6 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-#INPUT                  = ../README.md \
 INPUT                  = ../../amd_openvx/openvx/include/VX/vx.h \
                         ../../amd_openvx/openvx/include/VX/vx_api.h \
                         ../../amd_openvx/openvx/include/VX/vx_compatibility.h \
@@ -1171,7 +1170,6 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-#USE_MDFILE_AS_MAINPAGE = README.md
 USE_MDFILE_AS_MAINPAGE = 
 
 # The Fortran standard specifies that for fixed formatted Fortran code all

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ MIVisionX documentation
 
 MIVisionX is a comprehensive machine intelligence and computer vision toolkit. MIVisionX includes AMD's implementation of `Khronos OpenVX <https://www.khronos.org/openvx/>`_, as well as a Convolutional Neural Net model compiler and optimizer supporting the `ONNX <https://onnx.ai/>`_ and `Khronos NNEF <https://www.khronos.org/nnef>`_ exchange formats. The MIVisionX toolkit is used for rapid prototyping and deployment of optimized computer vision and machine learning inference workloads on a wide range of computer hardware, including on small embedded CPUs, APUs, discrete GPUs, and heterogeneous servers.
 
- The MIVisionX public repository is located at `https://github.com/ROCm/MIVisionX <https://github.com/ROCm/MIVisionX>`_.
+The MIVisionX public repository is located at `https://github.com/ROCm/MIVisionX <https://github.com/ROCm/MIVisionX>`_.
 
 .. grid:: 2
   :gutter: 3
@@ -37,7 +37,9 @@ MIVisionX is a comprehensive machine intelligence and computer vision toolkit. M
     * :doc:`MIVisionX toolkits <./reference/MIVisionX-toolkits>`
     * :doc:`MIVisionX supported models and operators <./reference/MIVisionX-supported-models>`
     * :doc:`MIVisionX environment variables <./reference/MIVisionX-env-variables>`
+    * :doc:`MIVisionX API reference <doxygen/html/files>`
     * :doc:`MIVisionX API reference <doxygen/html/modules>`
+    * :doc:`MIVisionX API reference <doxygen/html/annotated>`
 
 
   .. grid-item-card:: Examples

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,9 +37,7 @@ The MIVisionX public repository is located at `https://github.com/ROCm/MIVisionX
     * :doc:`MIVisionX toolkits <./reference/MIVisionX-toolkits>`
     * :doc:`MIVisionX supported models and operators <./reference/MIVisionX-supported-models>`
     * :doc:`MIVisionX environment variables <./reference/MIVisionX-env-variables>`
-    * :doc:`MIVisionX API reference <doxygen/html/files>`
     * :doc:`MIVisionX API reference <doxygen/html/modules>`
-    * :doc:`MIVisionX API reference <doxygen/html/annotated>`
 
 
   .. grid-item-card:: Examples

--- a/docs/install/MIVisionX-install-OpenVX.rst
+++ b/docs/install/MIVisionX-install-OpenVX.rst
@@ -23,8 +23,8 @@ Build Instructions
 
 Build this project to generate AMD OpenVX library 
 
-* Refer to `openvx/include/VX <https://github.com/ROCm/MIVisionX/tree/master/amd_openvx/openvx/include>`_ for Khronos OpenVX standard header files.
-* Refer to `openvx/include/vx_ext_amd.h <https://github.com/ROCm/MIVisionX/tree/master/amd_openvx/openvx/include/vx_ext_amd.h>`_ for vendor extensions in AMD OpenVX library
+* Refer to `openvx/include/VX <https://github.com/ROCm/MIVisionX/tree/develop/amd_openvx/openvx/include>`_ for Khronos OpenVX standard header files.
+* Refer to `openvx/include/vx_ext_amd.h <https://github.com/ROCm/MIVisionX/tree/develop/amd_openvx/openvx/include/vx_ext_amd.h>`_ for vendor extensions in AMD OpenVX library
 
 Build using Microsoft Visual Studio
 -------------------------------------

--- a/docs/install/MIVisionX-prerequisites.rst
+++ b/docs/install/MIVisionX-prerequisites.rst
@@ -8,7 +8,7 @@ MIVisionX prerequisites
 
 MIVisionX can be used with or without ROCm.
 
-MIVisionX on ROCm requires ROCm running on an `accelerators based on the CDNA architecture <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html>`_ installed with the AMDGPU installer and the ``rocm`` usecase:
+MIVisionX on ROCm requires ROCm running on an `GPUs based on the CDNA architecture <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html>`_ installed with the AMDGPU installer and the ``rocm`` usecase:
 
 .. code:: shell
 

--- a/docs/reference/MIVisionX-AMD-Openvx.rst
+++ b/docs/reference/MIVisionX-AMD-Openvx.rst
@@ -12,7 +12,7 @@ AMD OpenVX is an open-source implementation of the |openvx|_ computer vision spe
 
 AMD OpenVX can be found in the `MIVisionX GitHub repository <https://github.com/ROCm/MIVisionX/blob/develop/amd_openvx>`_.
 
-`RunVX <https://github.com/ROCm/MIVisionX/tree/master/utilities/runvx>`_ provides a means for rapid prototyping without re-compiling.
+`RunVX <https://github.com/ROCm/MIVisionX/tree/develop/utilities/runvx>`_ provides a means for rapid prototyping without re-compiling.
 
 In addition to implementing Khronos OPenVX functions and data type, `AMD OpenVX extends OpenVX <https://github.com/ROCm/MIVisionX/tree/develop/amd_openvx_extensions>`_ with the following modules and libraries:
 

--- a/docs/tutorials/MIVisionX-model-comp-samples.rst
+++ b/docs/tutorials/MIVisionX-model-comp-samples.rst
@@ -6,9 +6,9 @@
 MIVisionX model compiler samples
 ******************************************
 
-The sample applications available in `samples/model_compiler_samples <https://github.com/ROCm/MIVisionX/blob/master/samples/model_compiler_samples/README.md>`_, demonstrate how to run inference efficiently using AMD's open source implementation of OpenVX and OpenVX extensions. The samples review each step required to convert a pre-trained neural net model into an OpenVX graph and run this graph efficiently on the target hardware. 
+The sample applications available in `samples/model_compiler_samples <https://github.com/ROCm/MIVisionX/blob/develop/samples/model_compiler_samples/README.md>`_, demonstrate how to run inference efficiently using AMD's open source implementation of OpenVX and OpenVX extensions. The samples review each step required to convert a pre-trained neural net model into an OpenVX graph and run this graph efficiently on the target hardware. 
 
-* `Sample-1: Classification Using Pre-Trained ONNX Model <https://github.com/ROCm/MIVisionX/blob/master/samples/model_compiler_samples/README.md#sample-1---classification-using-pre-trained-onnx-model>`_
-* `Sample-2: Detection Using Pre-Trained Caffe Model <https://github.com/ROCm/MIVisionX/blob/master/samples/model_compiler_samples/README.md#sample-2---detection-using-pre-trained-caffe-model>`_ 
-* `Sample-3: Classification Using Pre-Trained NNEF Model <https://github.com/ROCm/MIVisionX/blob/master/samples/model_compiler_samples/README.md#sample-3---classification-using-pre-trained-nnef-model>`_
-* `Sample-4: Classification Using Pre-Trained Caffe Model <https://github.com/ROCm/MIVisionX/blob/master/samples/model_compiler_samples/README.md#sample-4---classification-using-pre-trained-caffe-model>`_
+* `Sample-1: Classification Using Pre-Trained ONNX Model <https://github.com/ROCm/MIVisionX/blob/develop/samples/model_compiler_samples/README.md#sample-1---classification-using-pre-trained-onnx-model>`_
+* `Sample-2: Detection Using Pre-Trained Caffe Model <https://github.com/ROCm/MIVisionX/blob/develop/samples/model_compiler_samples/README.md#sample-2---detection-using-pre-trained-caffe-model>`_ 
+* `Sample-3: Classification Using Pre-Trained NNEF Model <https://github.com/ROCm/MIVisionX/blob/develop/samples/model_compiler_samples/README.md#sample-3---classification-using-pre-trained-nnef-model>`_
+* `Sample-4: Classification Using Pre-Trained Caffe Model <https://github.com/ROCm/MIVisionX/blob/develop/samples/model_compiler_samples/README.md#sample-4---classification-using-pre-trained-caffe-model>`_


### PR DESCRIPTION
## Motivation

The master branch is no longer maintained, but there were still links to it in the docs. 

Have changed those links to point to the develop branch, and did some other small cleanup in the process.