### PR TITLE
Fix - Memory leak

### DIFF
--- a/amd_openvx/openvx/ago/ago_util.cpp
+++ b/amd_openvx/openvx/ago/ago_util.cpp
@@ -2804,6 +2804,13 @@ int agoReleaseData(AgoData * data, bool isForExternalUse)
                     data->children[i] = NULL;
                 }
             }
+
+            // Free the array itself
+            if (data->children) {
+                delete[] data->children;
+                data->children = nullptr;
+            }
+
             // remove the data from graph
             if (agoRemoveData(&graph->dataList, data, nullptr)) {
                 agoAddLogEntry(&data->ref, VX_FAILURE, "ERROR: agoReleaseData: agoRemoveData(context,%s) failed\n", data->name.c_str());
@@ -2847,6 +2854,13 @@ int agoReleaseData(AgoData * data, bool isForExternalUse)
                     data->children[i] = NULL;
                 }
             }
+
+            // Free the array itself
+            if (data->children) {
+                delete[] data->children;
+                data->children = nullptr;
+            }
+
             // remove the data from context
             if (agoRemoveData(&context->dataList, data, nullptr)) {
                 agoAddLogEntry(&data->ref, VX_FAILURE, "ERROR: agoReleaseData: agoRemoveData(context,%s) failed\n", data->name.c_str());

--- a/amd_openvx/openvx/ago/ago_util.cpp
+++ b/amd_openvx/openvx/ago/ago_util.cpp
@@ -2805,7 +2805,6 @@ int agoReleaseData(AgoData * data, bool isForExternalUse)
                 }
             }
 
-            // Free the array itself
             if (data->children) {
                 delete[] data->children;
                 data->children = nullptr;
@@ -2855,7 +2854,6 @@ int agoReleaseData(AgoData * data, bool isForExternalUse)
                 }
             }
 
-            // Free the array itself
             if (data->children) {
                 delete[] data->children;
                 data->children = nullptr;


### PR DESCRIPTION
## Motivation

To fix memory leaks in amd_openvx 

## Technical Details

Fixed memory allocations in amd_openvx/openvx/ago/ago_util.cpp that were previously not freed properly.

## Test Plan

Ran all ctest tests and valgrind for memory leaks.

## Test Result

All ctests pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
