### PR TITLE
Fix error caused by asan changelog installing in same same path as runtime changelog

### DIFF
--- a/utils.cmake
+++ b/utils.cmake
@@ -42,9 +42,12 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
         if(NOT ${result} EQUAL 0)
           message(FATAL_ERROR "Failed to compress: ${error}")
         endif()
-        install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
-                  DESTINATION ${CMAKE_INSTALL_DOCDIR}
-                  COMPONENT ${COMPONENT_NAME_T})
+
+        if("${COMPONENT_NAME_T}" STREQUAL "runtime")
+          install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
+                    DESTINATION ${CMAKE_INSTALL_DOCDIR}
+                    COMPONENT ${COMPONENT_NAME_T})
+        endif()
       endif()
 
     else()

--- a/utils.cmake
+++ b/utils.cmake
@@ -1,5 +1,11 @@
 ## Configure Copyright File for Debian Package
 function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTAINER_NM_T MAINTAINER_EMAIL_T)
+    if("${COMPONENT_NAME_T}" STREQUAL "asan")
+      set(LINTIAN_DOCS_DIR "${CMAKE_INSTALL_DOCDIR}-asan")
+    else()
+      set(LINTIAN_DOCS_DIR ${CMAKE_INSTALL_DOCDIR})
+    endif()
+
     # Check If Debian Platform
     find_file (DEBIAN debian_version debconf.conf PATHS /etc)
     if(DEBIAN)
@@ -19,7 +25,7 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
 
       # Install copyright file
       install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/copyright.txt"
-      DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+      DESTINATION "${LINTIAN_DOCS_DIR}"
       COMPONENT ${COMPONENT_NAME_T} )
 
       # Configure the changelog file
@@ -43,17 +49,15 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
           message(FATAL_ERROR "Failed to compress: ${error}")
         endif()
 
-        if("${COMPONENT_NAME_T}" STREQUAL "runtime")
-          install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
-                    DESTINATION ${CMAKE_INSTALL_DOCDIR}
-                    COMPONENT ${COMPONENT_NAME_T})
-        endif()
+        install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
+                  DESTINATION ${LINTIAN_DOCS_DIR}
+                  COMPONENT ${COMPONENT_NAME_T})
       endif()
 
     else()
         # License file
         install ( FILES ${LICENSE_FILE}
-            DESTINATION ${CMAKE_INSTALL_DOCDIR} RENAME LICENSE.txt
+            DESTINATION ${LINTIAN_DOCS_DIR} RENAME LICENSE.txt
             COMPONENT ${COMPONENT_NAME_T})
     endif()
 endfunction()


### PR DESCRIPTION
## Motivation

Fix bug caused by asan changelog  installing in same location as runtime changelog 

## Technical Details

update install location for asan 

## Test Plan

check dir is correctly set. When installing confirm that dir is correct 

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
