### PR TITLE
ROCm 7.2.1 - Cherry-pick: CMakeLists: ASAN - Fix error 

### DIFF
--- a/utils.cmake
+++ b/utils.cmake
@@ -1,5 +1,11 @@
 ## Configure Copyright File for Debian Package
 function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTAINER_NM_T MAINTAINER_EMAIL_T)
+    if("${COMPONENT_NAME_T}" STREQUAL "asan")
+      set(LINTIAN_DOCS_DIR "${CMAKE_INSTALL_DOCDIR}-asan")
+    else()
+      set(LINTIAN_DOCS_DIR ${CMAKE_INSTALL_DOCDIR})
+    endif()
+
     # Check If Debian Platform
     find_file (DEBIAN debian_version debconf.conf PATHS /etc)
     if(DEBIAN)
@@ -19,7 +25,7 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
 
       # Install copyright file
       install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/copyright.txt"
-      DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+      DESTINATION "${LINTIAN_DOCS_DIR}"
       COMPONENT ${COMPONENT_NAME_T} )
 
       # Configure the changelog file
@@ -42,15 +48,16 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
         if(NOT ${result} EQUAL 0)
           message(FATAL_ERROR "Failed to compress: ${error}")
         endif()
+
         install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
-                  DESTINATION ${CMAKE_INSTALL_DOCDIR}
+                  DESTINATION ${LINTIAN_DOCS_DIR}
                   COMPONENT ${COMPONENT_NAME_T})
       endif()
 
     else()
         # License file
         install ( FILES ${LICENSE_FILE}
-            DESTINATION ${CMAKE_INSTALL_DOCDIR} RENAME LICENSE.txt
+            DESTINATION ${LINTIAN_DOCS_DIR} RENAME LICENSE.txt
             COMPONENT ${COMPONENT_NAME_T})
     endif()
 endfunction()


### PR DESCRIPTION
> [!IMPORTANT]
> RM approval required for merge

## Motivation

Asan driver install blocker in 7.2.1

## Technical Details

Fix ASAN package overwriting changelog from runtime package

## Test Plan

ASAN package build and install

## Test Result

ASAN should install without overwriting any files

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
