### PR TITLE
Add Erode and Dilate Host support

### DIFF
--- a/amd_openvx_extensions/amd_rpp/source/tensor/Dilate.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/tensor/Dilate.cpp
@@ -50,8 +50,9 @@ static vx_status VX_CALLBACK refreshDilate(vx_node node, const vx_reference *par
         STATUS_ERROR_CHECK(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &data->pDst, sizeof(data->pDst)));
 #endif
     } else {
-        // HOST backend not implemented for Dilate
-        return VX_ERROR_NOT_SUPPORTED;
+        STATUS_ERROR_CHECK(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HOST, &roi_tensor_ptr, sizeof(roi_tensor_ptr)));
+        STATUS_ERROR_CHECK(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HOST, &data->pSrc, sizeof(data->pSrc)));
+        STATUS_ERROR_CHECK(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HOST, &data->pDst, sizeof(data->pDst)));
     }
     data->pSrcRoi = reinterpret_cast<RpptROI *>(roi_tensor_ptr);
 
@@ -125,8 +126,8 @@ static vx_status VX_CALLBACK processDilate(vx_node node, const vx_reference *par
         return_status = (rpp_status == RPP_SUCCESS) ? VX_SUCCESS : VX_FAILURE;
 #endif
     } else {
-        // HOST backend not implemented
-        return_status = VX_ERROR_NOT_SUPPORTED;
+        rpp_status = rppt_dilate_host(data->pSrc, data->pSrcDesc, data->pDst, data->pDstDesc, data->kernelSize, data->pSrcRoi, data->roiType, data->handle->rppHandle);
+        return_status = (rpp_status == RPP_SUCCESS) ? VX_SUCCESS : VX_FAILURE;
     }
 
     return return_status;

--- a/amd_openvx_extensions/amd_rpp/source/tensor/Erode.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/tensor/Erode.cpp
@@ -50,8 +50,9 @@ static vx_status VX_CALLBACK refreshErode(vx_node node, const vx_reference *para
         STATUS_ERROR_CHECK(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &data->pDst, sizeof(data->pDst)));
 #endif
     } else {
-        // HOST backend not implemented for Erode
-        return VX_ERROR_NOT_SUPPORTED;
+        STATUS_ERROR_CHECK(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HOST, &roi_tensor_ptr, sizeof(roi_tensor_ptr)));
+        STATUS_ERROR_CHECK(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HOST, &data->pSrc, sizeof(data->pSrc)));
+        STATUS_ERROR_CHECK(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HOST, &data->pDst, sizeof(data->pDst)));
     }
     data->pSrcRoi = reinterpret_cast<RpptROI *>(roi_tensor_ptr);
 
@@ -125,8 +126,8 @@ static vx_status VX_CALLBACK processErode(vx_node node, const vx_reference *para
         return_status = (rpp_status == RPP_SUCCESS) ? VX_SUCCESS : VX_FAILURE;
 #endif
     } else {
-        // HOST backend not supported
-        return_status = VX_ERROR_NOT_SUPPORTED;
+        rpp_status = rppt_erode_host(data->pSrc, data->pSrcDesc, data->pDst, data->pDstDesc, data->kernelSize, data->pSrcRoi, data->roiType, data->handle->rppHandle);
+        return_status = (rpp_status == RPP_SUCCESS) ? VX_SUCCESS : VX_FAILURE;
     }
 
     return return_status;


### PR DESCRIPTION
## Motivation

This PR adds Erode and Dilate Host support in amd_rpp extensions. The Erode and Dilate Host kernels were added in the recently merged RPP PRs [#666](https://github.com/ROCm/rpp/pull/666) and [#667](https://github.com/ROCm/rpp/pull/667)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
