### PR TITLE
fix for float4 init conformance test failures

### DIFF
--- a/amd_openvx/openvx/hipvx/filter_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/filter_kernels.cpp
@@ -7149,7 +7149,7 @@ Hip_ScaleGaussianHalf_U8_U8_3x3(uint dstWidth, uint dstHeight,
     v = fmaf(hip_unpack0(L1.z), 2.0f, v);
     v += hip_unpack0(L2.z);
     sum.w += v;
-    sum = sum * (float4)0.0625f;
+    sum = sum * make_float4(0.0625f, 0.0625f, 0.0625f, 0.0625f);
 
     if (valid) {
         *((uint *)(&pDstImage[dstIdx])) = hip_pack(sum);
@@ -7405,7 +7405,7 @@ Hip_ScaleGaussianHalf_U8_U8_5x5(uint dstWidth, uint dstHeight,
     sum.z += (float)(L0_01.y & 0xffff);
     sum.w += (float)(L0_01.y >> 16);
 
-    sum = sum * (float4)0.00390625f;
+    sum = sum * make_float4(0.00390625f, 0.00390625f, 0.00390625f, 0.00390625f);
     if (valid) {
         *((uint *)(&pDstImage[dstIdx])) = hip_pack(sum);
     }

--- a/amd_openvx/openvx/hipvx/geometric_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/geometric_kernels.cpp
@@ -494,8 +494,8 @@ Hip_ScaleImage_U8_U8_Area(uint dstWidth, uint dstHeight,
     }
 
     uint2 dst;
-    dst.x = hip_pack(make_float4(f.data[0], f.data[1], f.data[2], f.data[3]) * (float4)(iSxSy));
-    dst.y = hip_pack(make_float4(f.data[4], f.data[5], f.data[6], f.data[7]) * (float4)(iSxSy));
+    dst.x = hip_pack(make_float4(f.data[0], f.data[1], f.data[2], f.data[3]) * make_float4(iSxSy, iSxSy, iSxSy, iSxSy));
+    dst.y = hip_pack(make_float4(f.data[4], f.data[5], f.data[6], f.data[7]) * make_float4(iSxSy, iSxSy, iSxSy, iSxSy));
 
     *((uint2 *)(&pDstImage[dstIdx])) = dst;
 }
@@ -544,8 +544,8 @@ Hip_ScaleImage_U8_U8_Area_Sad(uint dstWidth, uint dstHeight,
     f.data[6] = (float)sum.data[6];
     f.data[7] = (float)sum.data[7];
 
-    dst.x = hip_pack(make_float4(f.data[0], f.data[1], f.data[2], f.data[3]) * (float4)(iSxSy));
-    dst.y = hip_pack(make_float4(f.data[4], f.data[5], f.data[6], f.data[7]) * (float4)(iSxSy));
+    dst.x = hip_pack(make_float4(f.data[0], f.data[1], f.data[2], f.data[3]) * make_float4(iSxSy, iSxSy, iSxSy, iSxSy));
+    dst.y = hip_pack(make_float4(f.data[4], f.data[5], f.data[6], f.data[7]) * make_float4(iSxSy, iSxSy, iSxSy, iSxSy));
 
     *((uint2 *)(&pDstImage[dstIdx])) = dst;
 }
@@ -715,8 +715,8 @@ Hip_ScaleImage_U8_U8_Area_Bytealign(uint dstWidth, uint dstHeight,
     }
 
     uint2 dst;
-    dst.x = hip_pack(make_float4(ftotal.data[0], ftotal.data[1], ftotal.data[2], ftotal.data[3]) * (float4)(iSxSy));
-    dst.y = hip_pack(make_float4(ftotal.data[4], ftotal.data[5], ftotal.data[6], ftotal.data[7]) * (float4)(iSxSy));
+    dst.x = hip_pack(make_float4(ftotal.data[0], ftotal.data[1], ftotal.data[2], ftotal.data[3]) * make_float4(iSxSy, iSxSy, iSxSy, iSxSy));
+    dst.y = hip_pack(make_float4(ftotal.data[4], ftotal.data[5], ftotal.data[6], ftotal.data[7]) * make_float4(iSxSy, iSxSy, iSxSy, iSxSy));
     *((uint2 *)(&pDstImage[dstIdx])) = dst;
 }
 

--- a/amd_openvx/openvx/hipvx/statistical_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/statistical_kernels.cpp
@@ -48,9 +48,10 @@ Hip_Threshold_U8_U8_Binary(uint dstWidth, uint dstHeight,
     uint2 src = *((uint2 *)(&pSrcImage[srcIdx]));
     uint2 dst;
 
-    float4 thr = (float4)hip_unpack0(thresholdValue);
-    dst.x = hip_pack((hip_unpack(src.x) - thr) * (float4)256.0f);
-    dst.y = hip_pack((hip_unpack(src.y) - thr) * (float4)256.0f);
+    float4 thr = make_float4(hip_unpack0(thresholdValue), hip_unpack0(thresholdValue),
+                         hip_unpack0(thresholdValue), hip_unpack0(thresholdValue));
+    dst.x = hip_pack((hip_unpack(src.x) - thr) * make_float4(256.0f, 256.0f, 256.0f, 256.0f));
+    dst.y = hip_pack((hip_unpack(src.y) - thr) * make_float4(256.0f, 256.0f, 256.0f, 256.0f));
 
     *((uint2 *)(&pDstImage[dstIdx])) = dst;
 }
@@ -90,14 +91,16 @@ Hip_Threshold_U8_U8_Range(uint dstWidth, uint dstHeight,
     uint2 src = *((uint2 *)(&pSrcImage[srcIdx]));
     uint2 dst;
 
-    float4 thr0 = (float4)(hip_unpack0(thresholdLower) - 1.0f);
-    float4 thr1 = (float4)(hip_unpack0(thresholdUpper) + 1.0f);
+    float thr0_val = hip_unpack0(thresholdLower) - 1.0f;
+    float thr1_val = hip_unpack0(thresholdUpper) + 1.0f;
+    float4 thr0 = make_float4(thr0_val, thr0_val, thr0_val, thr0_val);
+    float4 thr1 = make_float4(thr1_val, thr1_val, thr1_val, thr1_val);
     float4 pix0 = hip_unpack(src.x);
     float4 pix1 = hip_unpack(src.y);
-    dst.x  = hip_pack((pix0 - thr0) * (float4)256.0f);
-    dst.x &= hip_pack((thr1 - pix0) * (float4)256.0f);
-    dst.y  = hip_pack((pix1 - thr0) * (float4)256.0f);
-    dst.y &= hip_pack((thr1 - pix1) * (float4)256.0f);
+    dst.x  = hip_pack((pix0 - thr0) * make_float4(256.0f, 256.0f, 256.0f, 256.0f));
+    dst.x &= hip_pack((thr1 - pix0) * make_float4(256.0f, 256.0f, 256.0f, 256.0f));
+    dst.y  = hip_pack((pix1 - thr0) * make_float4(256.0f, 256.0f, 256.0f, 256.0f));
+    dst.y &= hip_pack((thr1 - pix1) * make_float4(256.0f, 256.0f, 256.0f, 256.0f));
 
     *((uint2 *)(&pDstImage[dstIdx])) = dst;
 }


### PR DESCRIPTION
## Motivation

Mivisionx Conformance test failures

## Technical Details

improper float4 initialization leads to these test failures

## Test Plan

Before fix the following test were failures

Threshold.OnRandom
Threshold.WithValidRegion
Scale.GraphProcessing
Scale.ImmediateProcessing
GaussianPyramid.GraphProcessing
GaussianPyramid.ImmediateProcessing
HalfScaleGaussian.GraphProcessing
HalfScaleGaussian.ImmediateProcessing

## Test Result

Upon running runConformanceTests.py with HIP backend
above test cases passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
