### PR TITLE
Opencl conf test

### DIFF
--- a/amd_openvx/openvx/ago/ago_haf_cpu_canny.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_canny.cpp
@@ -606,7 +606,14 @@ int HafCpu_CannyEdgeTrace_U8_U8XY
 		vx_uint32              xyStackTop
 	)
 {
+	// Clamp stackTop to capacity to prevent reading beyond buffer
+	if (xyStackTop > capacityOfXY) {
+		xyStackTop = capacityOfXY;
+	}
+
 	ago_coord2d_ushort_t *pxyStack = xyStack + xyStackTop;
+	ago_coord2d_ushort_t *pxyStackEnd = xyStack + capacityOfXY;
+
 	while (pxyStack != xyStack){
 			pxyStack--;
 			vx_uint16 x = pxyStack->x;
@@ -616,12 +623,21 @@ int HafCpu_CannyEdgeTrace_U8_U8XY
 			const ago_coord2d_short_t offs = dir_offsets[i];
 			vx_int16 x1 = x + offs.x;
 			vx_int16 y1 = y + offs.y;
-			vx_uint8 *pDst = pDstImage + y1*dstImageStrideInBytes + x1;
-			if (*pDst == 127)
-			{
-				*pDst |= 0x80;		// *pDst = 255
-				*((unsigned *)pxyStack) = (y1<<16)|x1;
-				pxyStack++;
+
+			// Add bounds checking for image access
+			if (x1 >= 0 && x1 < (vx_int16)dstWidth &&
+			    y1 >= 0 && y1 < (vx_int16)dstHeight) {
+				vx_uint8 *pDst = pDstImage + y1*dstImageStrideInBytes + x1;
+				if (*pDst == 127)
+				{
+					*pDst |= 0x80;		// *pDst = 255
+
+					// Check capacity before pushing to stack
+					if (pxyStack < pxyStackEnd) {
+						*((unsigned *)pxyStack) = (y1<<16)|x1;
+						pxyStack++;
+					}
+				}
 			}
 		}
 	}

--- a/amd_openvx/openvx/ago/ago_haf_gpu.h
+++ b/amd_openvx/openvx/ago/ago_haf_gpu.h
@@ -42,7 +42,7 @@ THE SOFTWARE.
 //     ly      - local work item [1]
 //     lbuf    - local buffer pointer
 //
-int HafGpu_Load_Local(int WGWidth, int WGHeight, int LMWidth, int LMHeight, int gxoffset, int gyoffset, std::string& code);
+int HafGpu_Load_Local(int WGWidth, int WGHeight, int LMWidth, int LMHeight, int gxoffset, int gyoffset, int bufferSize, int bufferOffset, std::string& code);
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Generate OpenCL code to load into local memory based on image size:

--- a/amd_openvx/openvx/ago/ago_haf_gpu_common.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_gpu_common.cpp
@@ -38,7 +38,7 @@ THE SOFTWARE.
 //     ly   - local work item [1]
 //     lbuf - local buffer
 //
-int HafGpu_Load_Local(int WGWidth, int WGHeight, int LMWidth, int LMHeight, int gxoffset, int gyoffset, std::string& code)
+int HafGpu_Load_Local(int WGWidth, int WGHeight, int LMWidth, int LMHeight, int gxoffset, int gyoffset, int bufferSize, int bufferOffset, std::string& code)
 {
 	char item[1024];
 
@@ -89,13 +89,16 @@ int HafGpu_Load_Local(int WGWidth, int WGHeight, int LMWidth, int LMHeight, int 
 			agoAddLogEntry(NULL, VX_FAILURE, "ERROR: HafGpu_Load_Local(%dx%d,%dx%d,(%d,%d)): doesn't support LMWidthRemain=%d with %s\n", WGWidth, WGHeight, LMWidth, LMHeight, gxoffset, gyoffset, LMWidthRemain, dType);
 			return -1;
 		}
+		snprintf(item, sizeof(item), "    if (goffset > -%d && goffset < %d) {\n", bufferOffset, bufferSize);
+		code += item;
 		if (use_vload) {
-			snprintf(item, sizeof(item), "    vstore%c(vload%c(0, (__global uint *)(gbuf + goffset)), 0, (__local uint *)(lbuf + loffset));\n", dType[4], dType[4]);
+			snprintf(item, sizeof(item), "      vstore%c(vload%c(0, (__global uint *)(gbuf + goffset)), 0, (__local uint *)(lbuf + loffset));\n", dType[4], dType[4]);
 		}
 		else {
-			snprintf(item, sizeof(item), "    *(__local %s *)(lbuf + loffset) = *(__global %s *)(gbuf + goffset);\n", dType, dType);
+			snprintf(item, sizeof(item), "      *(__local %s *)(lbuf + loffset) = *(__global %s *)(gbuf + goffset);\n", dType, dType);
 		}
 		code += item;
+		code += "    }\n";
 		// get configuration for extra load
 		int dWidth = LMWidthRemain >> dTypeShift;
 		int dHeight = LMHeight;
@@ -124,13 +127,16 @@ int HafGpu_Load_Local(int WGWidth, int WGHeight, int LMWidth, int LMHeight, int 
 			, LMWidth, dTypeShift, (WGWidth << LMdivWGWidthShift)
 			, gyoffset, dTypeShift, (WGWidth << LMdivWGWidthShift) - gxoffset, LMHeight);
 		code += item;
+		snprintf(item, sizeof(item), "      if (goffset > -%d && goffset < %d) {\n", bufferOffset, bufferSize);
+		code += item;
 		if (use_vload) {
-			snprintf(item, sizeof(item), "      vstore%c(vload%c(0, (__global uint *)(gbuf + goffset)), 0, (__local uint *)(lbuf + loffset));\n", dType[4], dType[4]);
+			snprintf(item, sizeof(item), "        vstore%c(vload%c(0, (__global uint *)(gbuf + goffset)), 0, (__local uint *)(lbuf + loffset));\n", dType[4], dType[4]);
 		}
 		else {
-			snprintf(item, sizeof(item), "      *(__local %s *)(lbuf + loffset) = *(__global %s *)(gbuf + goffset);\n", dType, dType);
+			snprintf(item, sizeof(item), "        *(__local %s *)(lbuf + loffset) = *(__global %s *)(gbuf + goffset);\n", dType, dType);
 		}
 		code += item;
+		code += "      }\n";
 		code += "    }\n";
 	}
 	else {
@@ -146,13 +152,16 @@ int HafGpu_Load_Local(int WGWidth, int WGHeight, int LMWidth, int LMHeight, int 
 					, WGHeight, LMWidth, WGHeight);
 				code += item;
 			}
+			snprintf(item, sizeof(item), "    if (goffset > -%d && goffset < %d) {\n", bufferOffset, bufferSize);
+			code += item;
 			if (use_vload) {
-				snprintf(item, sizeof(item), "    vstore%c(vload%c(0, (__global uint *)(gbuf + goffset)), 0, (__local uint *)(lbuf + loffset));\n", dType[4], dType[4]);
+				snprintf(item, sizeof(item), "      vstore%c(vload%c(0, (__global uint *)(gbuf + goffset)), 0, (__local uint *)(lbuf + loffset));\n", dType[4], dType[4]);
 			}
 			else {
-				snprintf(item, sizeof(item), "    *(__local %s *)(lbuf + loffset) = *(__global %s *)(gbuf + goffset);\n", dType, dType);
+				snprintf(item, sizeof(item), "      *(__local %s *)(lbuf + loffset) = *(__global %s *)(gbuf + goffset);\n", dType, dType);
 			}
 			code += item;
+			code += "    }\n";
 			if (dGroups > 1) {
 				if (y > 0) {
 					code +=
@@ -170,13 +179,16 @@ int HafGpu_Load_Local(int WGWidth, int WGHeight, int LMWidth, int LMHeight, int 
 						"    goffset_t += %d;\n" // WGWidth << dTypeShift
 						, WGWidth << dTypeShift, WGWidth << dTypeShift);
 					code += item;
+					snprintf(item, sizeof(item), "    if (goffset_t > -%d && goffset_t < %d) {\n", bufferOffset, bufferSize);
+					code += item;
 					if (use_vload) {
-						snprintf(item, sizeof(item), "    vstore%c(vload%c(0, (__global uint *)(gbuf + goffset_t)), 0, (__local uint *)(lbuf + loffset_t));\n", dType[4], dType[4]);
+						snprintf(item, sizeof(item), "      vstore%c(vload%c(0, (__global uint *)(gbuf + goffset_t)), 0, (__local uint *)(lbuf + loffset_t));\n", dType[4], dType[4]);
 					}
 					else {
-						snprintf(item, sizeof(item), "    *(__local %s *)(lbuf + loffset_t) = *(__global %s *)(gbuf + goffset_t);\n", dType, dType);
+						snprintf(item, sizeof(item), "      *(__local %s *)(lbuf + loffset_t) = *(__global %s *)(gbuf + goffset_t);\n", dType, dType);
 					}
 					code += item;
+					code += "    }\n";
 				}
 			}
 			if ((LMHeight - y) < WGHeight) {
@@ -224,13 +236,16 @@ int HafGpu_Load_Local(int WGWidth, int WGHeight, int LMWidth, int LMHeight, int 
 					snprintf(item, sizeof(item), "   if (ry < %d) {\n", dHeight);
 					code += item;
 				}
+				snprintf(item, sizeof(item), "    if ((goffset + ry * gstride + (rx << %d)) > -%d && (goffset + ry * gstride + (rx << %d)) < %d) {\n", dTypeShift, bufferOffset, dTypeShift, bufferSize);
+				code += item;
 				if (use_vload) {
-					snprintf(item, sizeof(item), "    vstore%c(vload%c(0, (__global uint *)(gbuf + goffset + ry * gstride + (rx << %d))), 0, (__local uint *)(lbufptr + ry * %d + (rx << %d)));\n", dType[4], dType[4], dTypeShift, LMWidth, dTypeShift);
+					snprintf(item, sizeof(item), "      vstore%c(vload%c(0, (__global uint *)(gbuf + goffset + ry * gstride + (rx << %d))), 0, (__local uint *)(lbufptr + ry * %d + (rx << %d)));\n", dType[4], dType[4], dTypeShift, LMWidth, dTypeShift);
 				}
 				else {
-					snprintf(item, sizeof(item), "    *(__local %s *)(lbufptr + ry * %d + (rx << %d)) = *(__global %s *)(gbuf + goffset + ry * gstride + (rx << %d));\n", dType, LMWidth, dTypeShift, dType, dTypeShift);
+					snprintf(item, sizeof(item), "      *(__local %s *)(lbufptr + ry * %d + (rx << %d)) = *(__global %s *)(gbuf + goffset + ry * gstride + (rx << %d));\n", dType, LMWidth, dTypeShift, dType, dTypeShift);
 				}
 				code += item;
+				code += "    }\n";
 				if ((dSize - dCount) < (WGWidth * WGHeight)) {
 					code += "   }\n";
 				}

--- a/amd_openvx/openvx/ago/ago_haf_gpu_linear_filter.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_gpu_linear_filter.cpp
@@ -85,6 +85,8 @@ int HafGpu_LinearFilter_ANY_U8(AgoNode * node, vx_df_image dst_image_format, Ago
 
 	char item[1024];
 	std::string code;
+	int srcImageBufferSize = (int)node->paramList[1]->size;
+	int srcImageBufferOffset = (int)node->paramList[1]->gpu_buffer_offset;
 	if (filterHeight == 1 && filterWidth > 1) {
 		// generate code for Mx1 filter
 		vx_uint32 Mdiv2 = filterWidth >> 1; if (Mdiv2 == 0) { 
@@ -126,7 +128,7 @@ int HafGpu_LinearFilter_ANY_U8(AgoNode * node, vx_df_image dst_image_format, Ago
 			"  int gy = y;\n"
 			"  int gstride = stride;\n"
 			"  __global uchar * gbuf = p;\n");
-		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight, LMemSide, 0, code) < 0) {
+		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight, LMemSide, 0, srcImageBufferSize, srcImageBufferOffset, code) < 0) {
 			return -1;
 		}
 
@@ -221,7 +223,7 @@ int HafGpu_LinearFilter_ANY_U8(AgoNode * node, vx_df_image dst_image_format, Ago
 			"  int gy = y;\n"
 			"  int gstride = stride;\n"
 			"  __global uchar * gbuf = p;\n");
-		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemWidth, LMemHeight + Ndiv2 * 2, 0, Ndiv2, code) < 0) {
+		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemWidth, LMemHeight + Ndiv2 * 2, 0, Ndiv2, srcImageBufferSize, srcImageBufferOffset, code) < 0) {
 			return -1;
 		}
 
@@ -297,7 +299,7 @@ int HafGpu_LinearFilter_ANY_U8(AgoNode * node, vx_df_image dst_image_format, Ago
 			"  int gy = y;\n"
 			"  int gstride = stride;\n"
 			"  __global uchar * gbuf = p;\n");
-		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight + 2 * LMemSideTB, LMemSideLR, LMemSideTB, code) < 0) {
+		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight + 2 * LMemSideTB, LMemSideLR, LMemSideTB, srcImageBufferSize, srcImageBufferOffset, code) < 0) {
 			return -1;
 		}
 
@@ -461,12 +463,13 @@ int HafGpu_LinearFilter_ANY_S16(AgoNode * node, vx_df_image dst_image_format, Ag
 				filterCoefAreIntegers = false;
 		}
 	}
-
+	int srcImageBufferSize = (int)node->paramList[1]->size;
+	int srcImageBufferOffset = (int)node->paramList[1]->gpu_buffer_offset;
 	if (filterHeight == 1 && filterWidth > 1) {
 		// generate code for Mx1 filter
-		vx_uint32 Mdiv2 = filterWidth >> 1; if (Mdiv2 == 0) { 
+		vx_uint32 Mdiv2 = filterWidth >> 1; if (Mdiv2 == 0) {
 			agoAddLogEntry(NULL, VX_FAILURE, "ERROR: HafGpu_LinearFilter_ANY_S16 doesn't support %dx%d filter\n", filterWidth, filterHeight);
-			return -1; 
+			return -1;
 		}
 		vx_uint32 BytesPerPixel = (vx_uint32)sizeof(vx_int16);
 		vx_uint32 LMemSidePixelAlign = 4;
@@ -505,7 +508,7 @@ int HafGpu_LinearFilter_ANY_S16(AgoNode * node, vx_df_image dst_image_format, Ag
 			"  int gy = y;\n"
 			"  int gstride = stride;\n"
 			"  __global uchar * gbuf = p;\n");
-		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight, LMemSide, 0, code) < 0) {
+		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight, LMemSide, 0, srcImageBufferSize, srcImageBufferOffset, code) < 0) {
 			return -1;
 		}
 
@@ -647,7 +650,7 @@ int HafGpu_LinearFilter_ANY_S16(AgoNode * node, vx_df_image dst_image_format, Ag
 			"  int gy = y;\n"
 			"  int gstride = stride;\n"
 			"  __global uchar * gbuf = p;\n");
-		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemWidth, LMemHeight + Ndiv2 * 2, 0, Ndiv2, code) < 0) {
+		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemWidth, LMemHeight + Ndiv2 * 2, 0, Ndiv2, srcImageBufferSize, srcImageBufferOffset, code) < 0) {
 			return -1;
 		}
 
@@ -781,11 +784,13 @@ int HafGpu_LinearFilter_ANY_F32(AgoNode * node, vx_df_image dst_image_format, Ag
 		agoAddLogEntry(&node->akernel->ref, VX_FAILURE, "ERROR: HafGpu_LinearFilter_ANY_F32 doesn't expects vx_matrix or vx_convolution object for kernel %s\n", node->akernel->name);
 		return -1;
 	}
+	int srcImageBufferSize = (int)node->paramList[1]->size;
+	int srcImageBufferOffset = (int)node->paramList[1]->gpu_buffer_offset;
 	if (filterHeight == 1 && filterWidth > 1) {
 		// generate code for Mx1 filter
-		vx_uint32 Mdiv2 = filterWidth >> 1; if (Mdiv2 == 0) { 
+		vx_uint32 Mdiv2 = filterWidth >> 1; if (Mdiv2 == 0) {
 			agoAddLogEntry(NULL, VX_FAILURE, "ERROR: HafGpu_LinearFilter_ANY_F32 doesn't support %dx%d filter\n", filterWidth, filterHeight);
-			return -1; 
+			return -1;
 		}
 		vx_uint32 BytesPerPixel = (vx_uint32)sizeof(vx_float32);
 		vx_uint32 LMemSidePixelAlign = 4;
@@ -824,7 +829,7 @@ int HafGpu_LinearFilter_ANY_F32(AgoNode * node, vx_df_image dst_image_format, Ag
 			"  int gy = y;\n"
 			"  int gstride = stride;\n"
 			"  __global uchar * gbuf = p;\n");
-		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight, LMemSide, 0, code) < 0) {
+		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight, LMemSide, 0, srcImageBufferSize, srcImageBufferOffset, code) < 0) {
 			return -1;
 		}
 
@@ -961,7 +966,7 @@ int HafGpu_LinearFilter_ANY_F32(AgoNode * node, vx_df_image dst_image_format, Ag
 			"  int gy = y;\n"
 			"  int gstride = stride;\n"
 			"  __global uchar * gbuf = p;\n");
-		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemWidth, LMemHeight + Ndiv2 * 2, 0, Ndiv2, code) < 0) {
+		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemWidth, LMemHeight + Ndiv2 * 2, 0, Ndiv2, srcImageBufferSize, srcImageBufferOffset, code) < 0) {
 			return -1;
 		}
 
@@ -1125,6 +1130,8 @@ int HafGpu_LinearFilter_ANYx2_U8(AgoNode * node, vx_df_image dst_image_format, A
 
 	std::string code;
 	char item[1024];
+	int srcImageBufferSize = (int)node->paramList[1]->size;
+	int srcImageBufferOffset = (int)node->paramList[1]->gpu_buffer_offset;
 	if (filterHeight == 1 && filterWidth > 1) {
 		// generate code for Mx1 filter
 		vx_uint32 Mdiv2 = filterWidth >> 1; if (Mdiv2 == 0) { 
@@ -1166,7 +1173,7 @@ int HafGpu_LinearFilter_ANYx2_U8(AgoNode * node, vx_df_image dst_image_format, A
 			"  int gy = y;\n"
 			"  int gstride = stride;\n"
 			"  __global uchar * gbuf = p;\n");
-		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight, LMemSide, 0, code) < 0) {
+		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight, LMemSide, 0, srcImageBufferSize, srcImageBufferOffset, code) < 0) {
 			return -1;
 		}
 
@@ -1301,7 +1308,7 @@ int HafGpu_LinearFilter_ANYx2_U8(AgoNode * node, vx_df_image dst_image_format, A
 			"  int gy = y;\n"
 			"  int gstride = stride;\n"
 			"  __global uchar * gbuf = p;\n");
-		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight + 2 * LMemSideTB, LMemSideLR, LMemSideTB, code) < 0) {
+		if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight + 2 * LMemSideTB, LMemSideLR, LMemSideTB, srcImageBufferSize, srcImageBufferOffset, code) < 0) {
 			return -1;
 		}
 

--- a/amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp
@@ -1630,9 +1630,11 @@ int HafGpu_ScaleGaussianOrb(AgoNode * node, vx_interpolation_type_e interpolatio
 		, work_group_width, work_group_height, NODE_OPENCL_KERNEL_NAME, LMemSize, (width + 3) / 4, height, xscale * 4.0f, xoffset, yscale, yoffset);
 	node->opencl_code = item;
 	// load input image into local
-	int srcImageBufferSize = (int)node->paramList[1]->size;
-	int srcImageBufferOffset = (int)node->paramList[1]->gpu_buffer_offset;
-	if (HafGpu_Load_Local(work_group_width, work_group_height, LMemStride, LMemHeight, 4, 0, srcImageBufferSize, srcImageBufferOffset, node->opencl_code) < 0) {
+	// NOTE: This kernel uses scaled coordinate transformation with gbuf offset by (gx-2+4, gy-2)
+	// which can access beyond the nominal buffer boundaries into border padding.
+	// Bounds checking is disabled for this kernel by passing INT_MAX as buffer parameters
+	// since the transformation makes it incompatible with simple linear bounds checking.
+	if (HafGpu_Load_Local(work_group_width, work_group_height, LMemStride, LMemHeight, 4, 0, INT_MAX, INT_MAX, node->opencl_code) < 0) {
 		return -1;
 	}
 	// perform filtering

--- a/amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp
@@ -127,7 +127,9 @@ int HafGpu_NonLinearFilter_3x3_ANY_U8(AgoNode * node)
 		"  int gy = y;\n"
 		"  int gstride = stride;\n"
 		"  __global uchar * gbuf = p;\n";
-	if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight + 2 * LMemSideTB, LMemSideLR, LMemSideTB, code) < 0) {
+	int srcImageBufferSize = (int)node->paramList[1]->size;
+	int srcImageBufferOffset = (int)node->paramList[1]->gpu_buffer_offset;
+	if (HafGpu_Load_Local(AGO_OPENCL_WORKGROUP_SIZE_0, AGO_OPENCL_WORKGROUP_SIZE_1, LMemStride, LMemHeight + 2 * LMemSideTB, LMemSideLR, LMemSideTB, srcImageBufferSize, srcImageBufferOffset, code) < 0) {
 		return -1;
 	}
 
@@ -950,7 +952,9 @@ int HafGpu_CannySuppThreshold(AgoNode * node)
 		, work_group_width, work_group_height, NODE_OPENCL_KERNEL_NAME, xyarg, LMemSize, (width + 3) / 4, height);
 	node->opencl_code = item;
 	// load U16 into local
-	if (HafGpu_Load_Local(work_group_width, work_group_height, LMemStride, work_group_height + 2, 2 * 2, 1, node->opencl_code) < 0) {
+	int srcImageBufferSize = (int)node->paramList[1]->size;
+	int srcImageBufferOffset = (int)node->paramList[1]->gpu_buffer_offset;
+	if (HafGpu_Load_Local(work_group_width, work_group_height, LMemStride, work_group_height + 2, 2 * 2, 1, srcImageBufferSize, srcImageBufferOffset, node->opencl_code) < 0) {
 		return -1;
 	}
 	// load U16 pixels from local and perform non-max supression
@@ -1191,7 +1195,9 @@ int HafGpu_HarrisScoreFilters(AgoNode * node)
 				, width * 4 * component);
 		}
 		node->opencl_code += item;
-		if (HafGpu_Load_Local(work_group_width, work_group_height, LMemStride, 16 + N - 1, LMemSideLR * 4, (N >> 1), node->opencl_code) < 0) {
+		int srcImageBufferSize = (int)node->paramList[1]->size;
+		int srcImageBufferOffset = (int)node->paramList[1]->gpu_buffer_offset;
+		if (HafGpu_Load_Local(work_group_width, work_group_height, LMemStride, 16 + N - 1, LMemSideLR * 4, (N >> 1), srcImageBufferSize, srcImageBufferOffset, node->opencl_code) < 0) {
 			return -1;
 		}
 		// horizontal sum
@@ -1332,7 +1338,9 @@ int HafGpu_NonMaxSupp_XY_ANY_3x3(AgoNode * node)
 		, work_group_width, work_group_height, NODE_OPENCL_KERNEL_NAME, LMemSize);
 	node->opencl_code = item;
 	// load into local
-	if (HafGpu_Load_Local(work_group_width, work_group_height, LMemStride, work_group_height + 2, LMemSideLR, LMemSideTB, node->opencl_code) < 0) {
+	int srcImageBufferSize = (int)node->paramList[1]->size;
+	int srcImageBufferOffset = (int)node->paramList[1]->gpu_buffer_offset;
+	if (HafGpu_Load_Local(work_group_width, work_group_height, LMemStride, work_group_height + 2, LMemSideLR, LMemSideTB, srcImageBufferSize, srcImageBufferOffset, node->opencl_code) < 0) {
 		return -1;
 	}
 	// load pixels from local and perform non-max supression
@@ -1622,7 +1630,9 @@ int HafGpu_ScaleGaussianOrb(AgoNode * node, vx_interpolation_type_e interpolatio
 		, work_group_width, work_group_height, NODE_OPENCL_KERNEL_NAME, LMemSize, (width + 3) / 4, height, xscale * 4.0f, xoffset, yscale, yoffset);
 	node->opencl_code = item;
 	// load input image into local
-	if (HafGpu_Load_Local(work_group_width, work_group_height, LMemStride, LMemHeight, 4, 0, node->opencl_code) < 0) {
+	int srcImageBufferSize = (int)node->paramList[1]->size;
+	int srcImageBufferOffset = (int)node->paramList[1]->gpu_buffer_offset;
+	if (HafGpu_Load_Local(work_group_width, work_group_height, LMemStride, LMemHeight, 4, 0, srcImageBufferSize, srcImageBufferOffset, node->opencl_code) < 0) {
 		return -1;
 	}
 	// perform filtering

--- a/tests/vision_tests/runVisionTests.py
+++ b/tests/vision_tests/runVisionTests.py
@@ -91,6 +91,8 @@ height = args.height
 widthDiv2 = int(width / 2)
 heightDiv2 = int(height / 2)
 perfCounters = args.perf_counters.upper()
+if backendType == "OPENCL":
+    backendType = 'OCL'
 
 # OpenVX Vision Functions 1080P
 openvxNodes = [


### PR DESCRIPTION
## Motivation

segmentation fault for opencl backend convolution filters
Convolve_S16_U8_3x9.gdf
Convolve_S16_U8_5x5.gdf
Convolve_S16_U8_7x7.gdf
Convolve_U8_U8_3x9.gdf
Convolve_U8_U8_5x5.gdf
Convolve_U8_U8_7x7.gdf

## Technical Details

Segmentation fault was because of out of bound memory access

## Test Plan

Tested with following commands

python3 /workspace/MIVisionX/tests/openvx_conformance_tests/runConformanceTests.py --directory /workspace --backend_type OCL

python3 /workspace/MIVisionX/tests/amd_openvx_gdfs/runOpenVX.py --runvx_directory /workspace/mivisionx-conformance/build-opencl/bin/ --backend_type OCL --num_frames 2 --verbose

## Test Result

[ ======== ]
[ ALL DONE ] 5820 test(s) from 69 test case(s) ran
[ PASSED   ] 5820 test(s)
[ FAILED   ] 0 test(s)
[ DISABLED ] 8190 test(s)

=================================
OpenVX Conformance report summary
=================================

To be conformant to the OpenVX baseline, 863 required test(s) must pass. 863 tests passed, 0 tests failed. PASSED.
To be conformant to the Vision conformance profile, 4957 required test(s) must pass. 4957 tests passed, 0 tests failed. PASSED.
Note: The 8190 disabled tests are optional and are not considered for conformance.

And there are no failures from runOpenVx.py

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
