### PR TITLE
[CMake] Set required flags for TheRock install and explicitly set RPATHs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,31 @@ set(VERSION "3.5.0")
 # Set Project Version and Language
 project(mivisionx VERSION ${VERSION} LANGUAGES CXX)
 
+# Determine if we are building using the TheRock install of ROCm.
+set(USING_THE_ROCK OFF)
+if (EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+    set(USING_THE_ROCK ON)
+endif()
+message("-- ${White}${PROJECT_NAME} -- USING_THE_ROCK: ${USING_THE_ROCK}${ColorReset}")
+
+# Set device library path for TheRock install of ROCm.
+if (USING_THE_ROCK)
+    if (NOT DEFINED ENV{HIP_DEVICE_LIB_PATH})
+        set(ENV{HIP_DEVICE_LIB_PATH} ${ROCM_PATH}/lib/llvm/amdgcn/bitcode)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "HIP_DEVICE_LIB_PATH=${ROCM_PATH}/lib/llvm/amdgcn/bitcode")
+    endif()
+endif()
+
+# Set HIP_PLATFORM to amd if not set. This is required before finding HIP.
+if (NOT DEFINED ENV{HIP_PLATFORM})
+    set(ENV{HIP_PLATFORM} "amd")
+endif()
+
+# Do not embed build-tree paths in binaries; install RPATH is set per target.
+set(CMAKE_SKIP_BUILD_RPATH ON)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+set(CMAKE_INSTALL_RPATH "\$ORIGIN/../lib")
+
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")
 include(GNUInstallDirs)
 
@@ -98,7 +123,6 @@ message("-- ${BoldBlue}MIVisionX Source Root Path -- ${MIVISIONX_ROOT_DIR}${Colo
 
 if(APPLE)
   set(CMAKE_MACOSX_RPATH ON)
-  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
   set(GPU_SUPPORT OFF)
   set(BACKEND "CPU")
   message("-- ${Magenta}Apple macOS Detected -- GPU Support turned OFF${ColourReset}")
@@ -186,7 +210,8 @@ if(NOT DEFINED MIN_DEPS_MODE)
   if(EXISTS "/etc/os-release")
     file(READ "/etc/os-release" OS_RELEASE)
     string(REGEX MATCH "22.04" UBUNTU_22_FOUND ${OS_RELEASE})
-    if(NOT UBUNTU_22_FOUND)
+    string(REGEX MATCH "24.04" UBUNTU_24_FOUND ${OS_RELEASE})
+    if(NOT UBUNTU_22_FOUND AND NOT UBUNTU_24_FOUND)
       set(MIN_DEPS_MODE ON)
       message("-- ${Yellow}${PROJECT_NAME} Warning -- Non-Ubuntu OS, Min dependency option turned on${ColourReset}")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,8 @@ if (NOT DEFINED ENV{HIP_PLATFORM})
     set(ENV{HIP_PLATFORM} "amd")
 endif()
 
-# Set RPATH to $ORIGIN/../lib for all targets.
-set(CMAKE_SKIP_BUILD_RPATH ON)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH OFF)
+set(CMAKE_BUILD_RPATH "\$ORIGIN/../lib;${ROCM_PATH}/lib")
 set(CMAKE_INSTALL_RPATH "\$ORIGIN/../lib")
 
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (NOT DEFINED ENV{HIP_PLATFORM})
     set(ENV{HIP_PLATFORM} "amd")
 endif()
 
-# Do not embed build-tree paths in binaries; install RPATH is set per target.
+# Set RPATH to $ORIGIN/../lib for all targets.
 set(CMAKE_SKIP_BUILD_RPATH ON)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 set(CMAKE_INSTALL_RPATH "\$ORIGIN/../lib")


### PR DESCRIPTION
## Description

This PR sets environment variables necessary to compile MIVisionX alongside TheRock with only `ROCM_PATH` set as an environment variable.

## Technical Details

* Sets `HIP_PLATFORM` to "amd" by default.
* Sets `HIP_DEVICE_LIB_PATH` when building with TheRock.
* Sets the global `INSTALL_RPATH` to `$ORIGIN/../lib`. This allows the dynamic linker to properly link targets (installed under `ROCM_PATH/bin` or `ROCM_PATH/lib` to other libraries relative to them within TheRock. This will work without `LD_LIBRARY_PATH` requiring to be set as an environment variable.

## Testing

* Build and tests installed under `ROCM_PATH/share/mivisionx/test` were verified on a ManyLinux docker container.
* `ldd` run on installed MIVisionX libraries and binaries to ensure that they properly link to their requirements.