### PR TITLE
Add OpenVX conformance test GitHub workflow

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -68,6 +68,7 @@ jobs:
           path: |
             build/lib/
             OpenVX-cts/build/bin/vx_test_conformance
+            OpenVX-cts/build/lib/
             OpenVX-cts/test_data/
           retention-days: 1
 
@@ -84,7 +85,7 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 300 ./bin/vx_test_conformance --filter="GraphBase.*:Logging.*:SmokeTestBase.*:SmokeTest.*:TargetBase.*:Target.*"
 
@@ -102,7 +103,7 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 600 ./bin/vx_test_conformance --filter="Graph.*:GraphCallback.*:GraphDelay.*:GraphROI.*:UserNode.*"
 
@@ -120,7 +121,7 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 300 ./bin/vx_test_conformance --filter="Scalar.*:Array.*:ObjectArray.*:Matrix.*:Convolution.*:Distribution.*:LUT.*:Histogram.*"
 
@@ -138,7 +139,7 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 600 ./bin/vx_test_conformance --filter="Image.*:vxCopyImagePatch.*:vxMapImagePatch.*:vxCreateImageFromChannel.*:vxCopyRemapPatch.*:vxMapRemapPatch.*"
 
@@ -156,7 +157,7 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 300 ./bin/vx_test_conformance --filter="ColorConvert.*:ChannelExtract.*:ChannelCombine.*:vxConvertDepth.*:vxuConvertDepth.*"
 
@@ -174,7 +175,7 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 600 ./bin/vx_test_conformance --filter="Box3x3.*:Gaussian3x3.*:Median3x3.*:Dilate3x3.*:Erode3x3.*:Sobel3x3.*:Magnitude.*:Phase.*:NonLinearFilter.*:Convolve.*:EqualizeHistogram.*"
 
@@ -192,7 +193,7 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 600 ./bin/vx_test_conformance --filter="vxAddSub.*:vxuAddSub.*:vxMultiply.*:vxuMultiply.*:vxBinOp8u.*:vxuBinOp8u.*:vxBinOp16s.*:vxuBinOp16s.*:vxBinOp1u.*:vxuBinOp1u.*:vxNot.*:vxuNot.*:WeightedAverage.*:Threshold.*"
 
@@ -210,7 +211,7 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 600 ./bin/vx_test_conformance --filter="Scale.*:WarpAffine.*:WarpPerspective.*:Remap.*:HalfScaleGaussian.*"
 
@@ -228,7 +229,7 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 600 ./bin/vx_test_conformance --filter="HarrisCorners.*:FastCorners.*:vxCanny.*:vxuCanny.*"
 
@@ -246,7 +247,7 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 300 ./bin/vx_test_conformance --filter="MeanStdDev.*:MinMaxLoc.*:Integral.*"
 
@@ -264,24 +265,6 @@ jobs:
         run: |
           chmod +x OpenVX-cts/build/bin/vx_test_conformance
           cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib:${{ github.workspace }}/OpenVX-cts/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 300 ./bin/vx_test_conformance --filter="GaussianPyramid.*:LaplacianPyramid.*:LaplacianReconstruct.*:OptFlowPyrLK.*"
-
-  extensions:
-    runs-on: ubuntu-22.04
-    needs: build
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts
-      - name: Run import/export extension tests
-        run: |
-          chmod +x OpenVX-cts/build/bin/vx_test_conformance
-          cd OpenVX-cts/build
-          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
-          timeout 300 ./bin/vx_test_conformance --filter="ExtensionObject.*"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,269 @@
+# Copyright (c) 2015 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+name: AMD OpenVX Conformance Tests
+
+on:
+  push:
+    branches: [master, main, develop]
+  pull_request:
+    branches: [master, main, develop]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake
+
+      - name: Build AMD OpenVX (CPU backend)
+        run: |
+          mkdir build && cd build
+          cmake .. -DGPU_SUPPORT=OFF
+          make -j$(nproc)
+
+      - name: Clone OpenVX CTS
+        run: |
+          git clone --depth 1 -b openvx_1.3 https://github.com/KhronosGroup/OpenVX-cts.git
+
+      - name: Build OpenVX CTS
+        run: |
+          cd OpenVX-cts
+          mkdir -p build && cd build
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DOPENVX_INCLUDES="${{ github.workspace }}/amd_openvx/openvx/include" \
+            -DOPENVX_LIBRARIES="${{ github.workspace }}/build/lib/libopenvx.so;${{ github.workspace }}/build/lib/libvxu.so;pthread;dl;m;rt" \
+            -DOPENVX_CONFORMANCE_VISION=ON
+          make -j$(nproc)
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            build/lib/
+            OpenVX-cts/build/bin/vx_test_conformance
+            OpenVX-cts/test_data/
+          retention-days: 1
+
+  baseline:
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run baseline tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 300 ./bin/vx_test_conformance --filter="GraphBase.*:Logging.*:SmokeTestBase.*:SmokeTest.*:TargetBase.*:Target.*"
+
+  graph:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run graph tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 600 ./bin/vx_test_conformance --filter="Graph.*:GraphCallback.*:GraphDelay.*:GraphROI.*:UserNode.*"
+
+  data-objects:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run data object tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 300 ./bin/vx_test_conformance --filter="Scalar.*:Array.*:ObjectArray.*:Matrix.*:Convolution.*:Distribution.*:LUT.*:Histogram.*"
+
+  image-ops:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run image operation tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 600 ./bin/vx_test_conformance --filter="Image.*:vxCopyImagePatch.*:vxMapImagePatch.*:vxCreateImageFromChannel.*:vxCopyRemapPatch.*:vxMapRemapPatch.*"
+
+  vision-color:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run color and channel tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 300 ./bin/vx_test_conformance --filter="ColorConvert.*:ChannelExtract.*:ChannelCombine.*:vxConvertDepth.*:vxuConvertDepth.*"
+
+  vision-filters:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run filter and morphology tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 600 ./bin/vx_test_conformance --filter="Box3x3.*:Gaussian3x3.*:Median3x3.*:Dilate3x3.*:Erode3x3.*:Sobel3x3.*:Magnitude.*:Phase.*:NonLinearFilter.*:Convolve.*:EqualizeHistogram.*"
+
+  vision-arithmetic:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run arithmetic and bitwise tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 600 ./bin/vx_test_conformance --filter="vxAddSub.*:vxuAddSub.*:vxMultiply.*:vxuMultiply.*:vxBinOp8u.*:vxuBinOp8u.*:vxBinOp16s.*:vxuBinOp16s.*:vxNot.*:vxuNot.*:WeightedAverage.*:Threshold.*"
+
+  vision-geometric:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run geometric transform tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 600 ./bin/vx_test_conformance --filter="Scale.*:WarpAffine.*:WarpPerspective.*:Remap.*:HalfScaleGaussian.*"
+
+  vision-features:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run feature and edge detection tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 600 ./bin/vx_test_conformance --filter="HarrisCorners.*:FastCorners.*:vxCanny.*:vxuCanny.*"
+
+  vision-statistics:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run statistics and analysis tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 300 ./bin/vx_test_conformance --filter="MeanStdDev.*:MinMaxLoc.*:Integral.*"
+
+  vision-pyramid:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run pyramid and optical flow tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 300 ./bin/vx_test_conformance --filter="GaussianPyramid.*:LaplacianPyramid.*:LaplacianReconstruct.*:OptFlowPyrLK.*"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -194,7 +194,7 @@ jobs:
           cd OpenVX-cts/build
           export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
-          timeout 600 ./bin/vx_test_conformance --filter="vxAddSub.*:vxuAddSub.*:vxMultiply.*:vxuMultiply.*:vxBinOp8u.*:vxuBinOp8u.*:vxBinOp16s.*:vxuBinOp16s.*:vxNot.*:vxuNot.*:WeightedAverage.*:Threshold.*"
+          timeout 600 ./bin/vx_test_conformance --filter="vxAddSub.*:vxuAddSub.*:vxMultiply.*:vxuMultiply.*:vxBinOp8u.*:vxuBinOp8u.*:vxBinOp16s.*:vxuBinOp16s.*:vxBinOp1u.*:vxuBinOp1u.*:vxNot.*:vxuNot.*:WeightedAverage.*:Threshold.*"
 
   vision-geometric:
     runs-on: ubuntu-22.04
@@ -267,3 +267,21 @@ jobs:
           export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
           export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
           timeout 300 ./bin/vx_test_conformance --filter="GaussianPyramid.*:LaplacianPyramid.*:LaplacianReconstruct.*:OptFlowPyrLK.*"
+
+  extensions:
+    runs-on: ubuntu-22.04
+    needs: build
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+      - name: Run import/export extension tests
+        run: |
+          chmod +x OpenVX-cts/build/bin/vx_test_conformance
+          cd OpenVX-cts/build
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+          export VX_TEST_DATA_PATH=${{ github.workspace }}/OpenVX-cts/test_data/
+          timeout 300 ./bin/vx_test_conformance --filter="ExtensionObject.*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,132 @@
+# MIVisionX
+
+AMD MIVisionX toolkit - version 3.5.0. Computer vision and machine intelligence libraries, utilities, and applications built on AMD OpenVX.
+
+## Project Structure
+
+```
+MIVisionX/
+├── amd_openvx/                    # Core AMD OpenVX implementation (v1.3.0)
+│   └── openvx/
+│       ├── ago/                   # AMD Graph Optimizer (AGO) engine - CPU & GPU kernels
+│       ├── api/                   # OpenVX API (vx_api.cpp, vx_nodes.cpp, vxu.cpp)
+│       ├── hipvx/                 # HIP GPU backend kernels
+│       └── include/               # Khronos OpenVX 1.3 standard headers (VX/) + AMD extensions
+├── amd_openvx_extensions/         # OpenVX extension modules
+│   ├── amd_nn/                    # Neural network extension (MIOpen-based)
+│   ├── amd_opencv/                # OpenCV interop extension
+│   ├── amd_media/                 # FFmpeg media extension
+│   ├── amd_rpp/                   # ROCm Performance Primitives extension
+│   ├── amd_migraphx/              # MIGraphX inference extension
+│   ├── amd_loomsl/                # Loom stitch library (OpenCL only)
+│   ├── amd_custom/                # Custom kernel extension (HIP only)
+│   └── amd_winml/                 # Windows ML extension
+├── utilities/                     # CLI tools
+│   ├── runvx/                     # OpenVX graph executor
+│   ├── runcl/                     # OpenCL kernel runner
+│   ├── mv_deploy/                 # Model deployment tool
+│   ├── loom_shell/                # Loom stitch shell
+│   └── loom_io_media/             # Loom I/O media
+├── tests/                         # Test suites
+│   ├── openvx_conformance_tests/  # Khronos OpenVX CTS runner (runConformanceTests.py)
+│   ├── openvx_api_tests/          # Individual API test programs
+│   ├── amd_openvx_gdfs/           # GDF (Graph Description Format) test scripts
+│   ├── vision_tests/              # Python-driven vision node tests
+│   ├── neural_network_tests/      # NN model import tests (caffe, onnx, nnef)
+│   └── ...                        # Extension-specific tests
+├── apps/                          # Sample applications
+├── model_compiler/                # Model compiler
+├── toolkit/                       # Additional toolkit utilities
+├── docker/                        # Dockerfiles (build, conformance, release)
+├── cmake/                         # CMake find modules
+├── docs/                          # Documentation (Sphinx-based)
+├── .github/workflows/             # GitHub Actions workflows
+│   ├── conformance.yml            # OpenVX conformance tests (CPU backend)
+│   └── codeql-analysis.yml        # CodeQL static analysis
+└── CMakeLists.txt                 # Top-level CMake (project: mivisionx)
+```
+
+## Build System
+
+CMake >= 3.10, C++17 required. Default compiler: `amdclang++` (from ROCm), falls back to system compiler.
+
+### Key CMake Options
+
+| Option | Values | Default | Description |
+|--------|--------|---------|-------------|
+| `BACKEND` | `HIP`, `OPENCL`/`OCL`, `CPU`/`host` | `HIP` | GPU backend (macOS forces `CPU`) |
+| `GPU_SUPPORT` | `ON`/`OFF` | `ON` | Enable GPU support (macOS forces `OFF`) |
+| `NEURAL_NET` | `ON`/`OFF` | `ON` | Neural net extension |
+| `LOOM` | `ON`/`OFF` | `ON` | Loom stitch library |
+| `MIGRAPHX` | `ON`/`OFF` | `OFF` | MIGraphX support |
+
+### Build Commands
+
+**CPU-only (HOST backend):**
+```bash
+mkdir build && cd build
+cmake .. -DGPU_SUPPORT=OFF
+make -j$(nproc)
+```
+
+**HIP backend:**
+```bash
+mkdir build && cd build
+cmake .. -DBACKEND=HIP
+make -j$(nproc)
+```
+
+**OpenCL backend:**
+```bash
+mkdir build && cd build
+cmake .. -DBACKEND=OCL
+make -j$(nproc)
+```
+
+Default install prefix: `${ROCM_PATH}` (defaults to `/opt/rocm`).
+
+### Build Output
+
+- Libraries go to `build/lib/` (`libopenvx.so`, `libvxu.so`, extensions)
+- Binaries go to `build/bin/` (`runvx`, `runcl`, etc.)
+
+## OpenVX Conformance Tests
+
+The Khronos OpenVX CTS is cloned from `https://github.com/KhronosGroup/OpenVX-cts.git` (branch `openvx_1.3`).
+
+### Running Conformance Locally
+
+Use the provided Python script:
+```bash
+python tests/openvx_conformance_tests/runConformanceTests.py --backend_type HOST
+```
+
+Options: `--backend_type` (`ALL`/`HOST`/`HIP`/`OCL`), `--jobs N`, `--skip-mivisionx-build`, `--skip-cts-build`, `--skip-cts-run`, `--directory`, `--cts-repo`, `--cts-branch`.
+
+### CTS Build Configuration
+
+The CTS needs these CMake variables pointing to the pre-built MIVisionX:
+- `OPENVX_INCLUDES` → `amd_openvx/openvx/include`
+- `OPENVX_LIBRARIES` → `libopenvx.so;libvxu.so;pthread;dl;m;rt`
+- `OPENVX_CONFORMANCE_VISION=ON`
+- `CMAKE_POLICY_VERSION_MINIMUM=3.5`
+
+### Runtime Environment
+
+- `LD_LIBRARY_PATH` must include the directory containing `libopenvx.so`
+- `VX_TEST_DATA_PATH` must point to `OpenVX-cts/test_data/`
+- `AGO_DEFAULT_TARGET` can be set to `CPU` or `GPU` (for OCL/HIP backends)
+
+## Git Workflow
+
+- Primary development branch: `develop`
+- CI triggers on: `master`, `main`, `develop`
+- Conformance workflow runs parallel test suites: baseline (required), graph, data-objects, image-ops, vision-color, vision-filters, vision-arithmetic, vision-geometric, vision-features, vision-statistics, vision-pyramid
+
+## Dependencies
+
+**Core (CPU-only):** CMake >= 3.10, C++17 compiler, SSE4.2 support
+**HIP backend:** ROCm (hip::host, hip::device)
+**OpenCL backend:** OpenCL libraries/headers
+**Extensions:** MIOpen, OpenCV 3.x/4.x, FFmpeg, RPP >= 3.1.0 (each optional)
+**Linux link libs:** `dl`, `m` (core); `pthread`, `dl`, `m`, `rt` (conformance tests)


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow (`.github/workflows/conformance.yml`) that builds AMD OpenVX with CPU backend, clones the Khronos OpenVX CTS (`openvx_1.3` branch), and runs all vision conformance tests in 11 parallel jobs
- Add `CLAUDE.md` with project structure, build system, conformance testing, and dependency documentation

## Workflow Details
- **Build job**: Builds MIVisionX with `-DGPU_SUPPORT=OFF`, clones and builds OpenVX CTS against the built libraries
- **11 parallel test jobs**: baseline (required), graph, data-objects, image-ops, vision-color, vision-filters, vision-arithmetic, vision-geometric, vision-features, vision-statistics, vision-pyramid
- Only the baseline job is required to pass; all other test jobs use `continue-on-error: true`
- Triggers on push/PR to `master`, `main`, and `develop` branches

## Test plan
- [x] Verify workflow triggers correctly on push to `develop`
- [x] Verify MIVisionX builds successfully with CPU backend on Ubuntu 22.04
- [x] Verify OpenVX CTS clones and builds against AMD OpenVX libraries
- [x] Verify baseline conformance tests pass
- [x] Verify all 11 test jobs run in parallel after build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)