### PR TITLE
AMD OpenVX - Round-2 CPU kernel optimizations for OpenCV parity

### DIFF
--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -33,7 +33,16 @@ static inline int HafCpu_PopCount32(unsigned int value)
 #endif
 }
 
-static inline void HafCpu_AccumulateSquaresU8_AVX2(__m256i bytes, __m256i &sum, __m256i &sumSquared)
+// Per-iter inner kernel: add 32 bytes' worth of pixels to `sum` (i64 lanes)
+// and 32 bytes' worth of pixel-squares to `sumSquaredI32` (i32 lanes). Caller
+// is responsible for periodically widening sumSquaredI32 into a 64-bit
+// accumulator so the i32 lanes don't overflow. The max per-iter contribution
+// to any sumSquaredI32 lane is (4 * 255^2) = 260,100 because madd_epi16
+// produces pair-sums; on a 32-byte block this gives 8 i32 partials with
+// a peak per-lane value of 4 * 65025 = 260,100. INT32_MAX / 260,100 ≈ 8255
+// iterations between flushes, but we conservatively flush every 8192 iters
+// (~262144 bytes) per accumulator slot.
+static inline void HafCpu_AccumulateU8_AVX2(__m256i bytes, __m256i &sum, __m256i &sumSquaredI32)
 {
 	const __m256i zero = _mm256_setzero_si256();
 	sum = _mm256_add_epi64(sum, _mm256_sad_epu8(bytes, zero));
@@ -42,16 +51,18 @@ static inline void HafCpu_AccumulateSquaresU8_AVX2(__m256i bytes, __m256i &sum, 
 	__m128i hi128 = _mm256_extracti128_si256(bytes, 1);
 	__m256i lo16 = _mm256_cvtepu8_epi16(lo128);
 	__m256i hi16 = _mm256_cvtepu8_epi16(hi128);
-	__m256i loSquares = _mm256_madd_epi16(lo16, lo16); // 8 x i32 partials
-	__m256i hiSquares = _mm256_madd_epi16(hi16, hi16); // 8 x i32 partials
+	// Pair-sum-of-squares produces two i32 accumulators per __m256i.
+	sumSquaredI32 = _mm256_add_epi32(sumSquaredI32, _mm256_madd_epi16(lo16, lo16));
+	sumSquaredI32 = _mm256_add_epi32(sumSquaredI32, _mm256_madd_epi16(hi16, hi16));
+}
 
-	// Widen each i32 squared partial to i64 and accumulate directly into the
-	// 64-bit running sum. This matches the SSE path's precision and avoids any
-	// chance of 32-bit overflow on sufficiently wide images.
-	sumSquared = _mm256_add_epi64(sumSquared, _mm256_cvtepu32_epi64(_mm256_castsi256_si128(loSquares)));
-	sumSquared = _mm256_add_epi64(sumSquared, _mm256_cvtepu32_epi64(_mm256_extracti128_si256(loSquares, 1)));
-	sumSquared = _mm256_add_epi64(sumSquared, _mm256_cvtepu32_epi64(_mm256_castsi256_si128(hiSquares)));
-	sumSquared = _mm256_add_epi64(sumSquared, _mm256_cvtepu32_epi64(_mm256_extracti128_si256(hiSquares, 1)));
+// Widen a 256-bit i32 partial sum into a 64-bit running total (8 i32 lanes ->
+// 8 i64 lanes, summed pairwise into 4 i64 lanes).
+static inline __m256i HafCpu_WidenAddI32ToI64_AVX2(__m256i acc64, __m256i partsI32)
+{
+	__m256i lo = _mm256_cvtepu32_epi64(_mm256_castsi256_si128(partsI32));
+	__m256i hi = _mm256_cvtepu32_epi64(_mm256_extracti128_si256(partsI32, 1));
+	return _mm256_add_epi64(acc64, _mm256_add_epi64(lo, hi));
 }
 #endif
 
@@ -7154,9 +7165,19 @@ int HafCpu_MeanStdDev_DATA_U8
 {
 #if USE_AVX
 	__m256i sum = _mm256_setzero_si256();
-	__m256i sumSquared = _mm256_setzero_si256();
+	__m256i sumSquared64 = _mm256_setzero_si256();
+	__m256i sumSquared32 = _mm256_setzero_si256();
 	unsigned long long tailSum = 0;
 	unsigned long long tailSumSquared = 0;
+
+	// Flush the i32 squared-partials into the i64 running total every
+	// `flushInterval` 32-byte iterations to break the long dependency chain
+	// the previous "widen every iter" version had on `sumSquared`.
+	// Safety: each iter contributes up to 8 * (4 * 255^2) = 2,080,800 to a
+	// single i32 lane; INT32_MAX / 2,080,800 ≈ 1032 iters max, so 1024 is
+	// a safe flush cadence.
+	const vx_uint32 flushInterval = 1024;
+	vx_uint32 itersSinceFlush = 0;
 
 	for (vx_uint32 y = 0; y < srcHeight; y++)
 	{
@@ -7165,7 +7186,13 @@ int HafCpu_MeanStdDev_DATA_U8
 		for (; x + 32 <= srcWidth; x += 32)
 		{
 			__m256i pixels = _mm256_loadu_si256((__m256i *)(pLocalSrc + x));
-			HafCpu_AccumulateSquaresU8_AVX2(pixels, sum, sumSquared);
+			HafCpu_AccumulateU8_AVX2(pixels, sum, sumSquared32);
+			if (++itersSinceFlush >= flushInterval)
+			{
+				sumSquared64 = HafCpu_WidenAddI32ToI64_AVX2(sumSquared64, sumSquared32);
+				sumSquared32 = _mm256_setzero_si256();
+				itersSinceFlush = 0;
+			}
 		}
 		for (; x < srcWidth; x++)
 		{
@@ -7175,11 +7202,13 @@ int HafCpu_MeanStdDev_DATA_U8
 		}
 		pSrcImage += srcImageStrideInBytes;
 	}
+	// Final flush
+	sumSquared64 = HafCpu_WidenAddI32ToI64_AVX2(sumSquared64, sumSquared32);
 
 	DECL_ALIGN(32) unsigned long long sumParts[4] ATTR_ALIGN(32);
 	DECL_ALIGN(32) unsigned long long squareParts[4] ATTR_ALIGN(32);
 	_mm256_store_si256((__m256i *)sumParts, sum);
-	_mm256_store_si256((__m256i *)squareParts, sumSquared);
+	_mm256_store_si256((__m256i *)squareParts, sumSquared64);
 	*pSum = (vx_float32)(sumParts[0] + sumParts[1] + sumParts[2] + sumParts[3] + tailSum);
 	*pSumOfSquared = (vx_float32)(squareParts[0] + squareParts[1] + squareParts[2] + squareParts[3] + tailSumSquared);
 	return AGO_SUCCESS;
@@ -7801,19 +7830,44 @@ int HafCpu_MinMax_DATA_U8
 	)
 {
 #if USE_AVX
-	__m256i maxVal_ymm = _mm256_setzero_si256();
-	__m256i minVal_ymm = _mm256_set1_epi8((char)0xFF);
+	// Use four independent min/max accumulator chains to break the per-iter
+	// dependency between successive _mm256_max/min_epu8 ops, doubling the
+	// effective throughput on cores with multiple int execution ports.
+	__m256i maxVal_a = _mm256_setzero_si256();
+	__m256i maxVal_b = _mm256_setzero_si256();
+	__m256i maxVal_c = _mm256_setzero_si256();
+	__m256i maxVal_d = _mm256_setzero_si256();
+	const __m256i ones = _mm256_set1_epi8((char)0xFF);
+	__m256i minVal_a = ones;
+	__m256i minVal_b = ones;
+	__m256i minVal_c = ones;
+	__m256i minVal_d = ones;
 	unsigned char maxVal = 0, minVal = 255;
 
 	for (vx_uint32 y = 0; y < srcHeight; y++)
 	{
 		vx_uint8 *pLocalSrc = pSrcImage;
 		vx_uint32 x = 0;
+		for (; x + 128 <= srcWidth; x += 128)
+		{
+			__m256i p0 = _mm256_loadu_si256((__m256i *)(pLocalSrc + x));
+			__m256i p1 = _mm256_loadu_si256((__m256i *)(pLocalSrc + x + 32));
+			__m256i p2 = _mm256_loadu_si256((__m256i *)(pLocalSrc + x + 64));
+			__m256i p3 = _mm256_loadu_si256((__m256i *)(pLocalSrc + x + 96));
+			maxVal_a = _mm256_max_epu8(maxVal_a, p0);
+			maxVal_b = _mm256_max_epu8(maxVal_b, p1);
+			maxVal_c = _mm256_max_epu8(maxVal_c, p2);
+			maxVal_d = _mm256_max_epu8(maxVal_d, p3);
+			minVal_a = _mm256_min_epu8(minVal_a, p0);
+			minVal_b = _mm256_min_epu8(minVal_b, p1);
+			minVal_c = _mm256_min_epu8(minVal_c, p2);
+			minVal_d = _mm256_min_epu8(minVal_d, p3);
+		}
 		for (; x + 32 <= srcWidth; x += 32)
 		{
 			__m256i pixels = _mm256_loadu_si256((__m256i *)(pLocalSrc + x));
-			maxVal_ymm = _mm256_max_epu8(maxVal_ymm, pixels);
-			minVal_ymm = _mm256_min_epu8(minVal_ymm, pixels);
+			maxVal_a = _mm256_max_epu8(maxVal_a, pixels);
+			minVal_a = _mm256_min_epu8(minVal_a, pixels);
 		}
 		for (; x < srcWidth; x++)
 		{
@@ -7823,15 +7877,21 @@ int HafCpu_MinMax_DATA_U8
 		pSrcImage += srcImageStrideInBytes;
 	}
 
-	DECL_ALIGN(32) unsigned char maxBytes[32] ATTR_ALIGN(32);
-	DECL_ALIGN(32) unsigned char minBytes[32] ATTR_ALIGN(32);
-	_mm256_store_si256((__m256i *)maxBytes, maxVal_ymm);
-	_mm256_store_si256((__m256i *)minBytes, minVal_ymm);
-	for (int i = 0; i < 32; i++)
-	{
-		maxVal = max(maxVal, maxBytes[i]);
-		minVal = min(minVal, minBytes[i]);
-	}
+	maxVal_a = _mm256_max_epu8(_mm256_max_epu8(maxVal_a, maxVal_b), _mm256_max_epu8(maxVal_c, maxVal_d));
+	minVal_a = _mm256_min_epu8(_mm256_min_epu8(minVal_a, minVal_b), _mm256_min_epu8(minVal_c, minVal_d));
+	// Fold 256-bit accumulators down to a single byte via in-lane reductions.
+	__m128i maxLo = _mm_max_epu8(_mm256_castsi256_si128(maxVal_a), _mm256_extracti128_si256(maxVal_a, 1));
+	__m128i minLo = _mm_min_epu8(_mm256_castsi256_si128(minVal_a), _mm256_extracti128_si256(minVal_a, 1));
+	maxLo = _mm_max_epu8(maxLo, _mm_srli_si128(maxLo, 8));
+	minLo = _mm_min_epu8(minLo, _mm_srli_si128(minLo, 8));
+	maxLo = _mm_max_epu8(maxLo, _mm_srli_si128(maxLo, 4));
+	minLo = _mm_min_epu8(minLo, _mm_srli_si128(minLo, 4));
+	maxLo = _mm_max_epu8(maxLo, _mm_srli_si128(maxLo, 2));
+	minLo = _mm_min_epu8(minLo, _mm_srli_si128(minLo, 2));
+	maxLo = _mm_max_epu8(maxLo, _mm_srli_si128(maxLo, 1));
+	minLo = _mm_min_epu8(minLo, _mm_srli_si128(minLo, 1));
+	maxVal = max(maxVal, (unsigned char)_mm_cvtsi128_si32(maxLo));
+	minVal = min(minVal, (unsigned char)_mm_cvtsi128_si32(minLo));
 	*pDstMinValue = (vx_int32)minVal;
 	*pDstMaxValue = (vx_int32)maxVal;
 	return AGO_SUCCESS;
@@ -7916,12 +7976,40 @@ int HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min
 	*pDstMinValue = globalMin;
 	*pDstMaxValue = globalMax;
 
-	// Search for the min values in the source image
-	__m128i minVal = _mm_set1_epi8((unsigned char)globalMin);
-	__m128i pixels;
+	// Search for the min values in the source image. Use AVX2 32-byte chunks
+	// + popcount on the 32-bit movemask to eliminate the SSE path's
+	// branch-heavy per-bit iteration loop, which was the dominant cost on
+	// images with many tied-min pixels.
+	const vx_uint8 globalMinU8 = (vx_uint8)globalMin;
 	int minCount = 0;
 	unsigned char * pLocalSrc;
 
+#if USE_AVX
+	const __m256i minVal256 = _mm256_set1_epi8((char)globalMinU8);
+	int alignedWidth = (int)srcWidth & ~31;
+	int postfixWidth = (int)srcWidth - alignedWidth;
+
+	for (int height = 0; height < (int)srcHeight; height++)
+	{
+		pLocalSrc = (unsigned char *)pSrcImage;
+		for (int width = 0; width < alignedWidth; width += 32)
+		{
+			__m256i pixels = _mm256_loadu_si256((__m256i *)pLocalSrc);
+			__m256i eq = _mm256_cmpeq_epi8(pixels, minVal256);
+			unsigned int mask = (unsigned int)_mm256_movemask_epi8(eq);
+			minCount += HafCpu_PopCount32(mask);
+			pLocalSrc += 32;
+		}
+		for (int width = 0; width < postfixWidth; width++)
+		{
+			if (*pLocalSrc == globalMinU8)
+				minCount++;
+			pLocalSrc++;
+		}
+		pSrcImage += srcImageStrideInBytes;
+	}
+#else
+	__m128i minVal = _mm_set1_epi8((char)globalMinU8);
 	int prefixWidth = intptr_t(pSrcImage) & 15;
 	prefixWidth = (prefixWidth == 0) ? 0 : (16 - prefixWidth);
 	int postfixWidth = ((int)srcWidth - prefixWidth) & 15;
@@ -7933,7 +8021,7 @@ int HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min
 		int width = 0;
 		while (width < prefixWidth)
 		{
-			if (*pLocalSrc == globalMin)
+			if (*pLocalSrc == globalMinU8)
 				minCount++;
 			width++;
 			pLocalSrc++;
@@ -7941,28 +8029,21 @@ int HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min
 
 		while (width < alignedWidth)
 		{
-			int minMask;
-
-			pixels = _mm_load_si128((__m128i *) pLocalSrc);
+			__m128i pixels = _mm_load_si128((__m128i *) pLocalSrc);
 			pixels = _mm_cmpeq_epi8(pixels, minVal);
-			minMask = _mm_movemask_epi8(pixels);
-
-			if (minMask)
-			{
-				for (int i = 0; i < 16; i++)
-				{
-					if (minMask & 1)
-						minCount++;
-					minMask >>= 1;
-				}
-			}
+			unsigned int minMask = (unsigned int)_mm_movemask_epi8(pixels);
+#if _WIN32
+			minCount += (int)__popcnt(minMask);
+#else
+			minCount += __builtin_popcount(minMask);
+#endif
 			width += 16;
 			pLocalSrc += 16;
 		}
 
 		while (width < (int)srcWidth)
 		{
-			if (*pLocalSrc == globalMin)
+			if (*pLocalSrc == globalMinU8)
 				minCount++;
 			width++;
 			pLocalSrc++;
@@ -7970,6 +8051,7 @@ int HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min
 
 		pSrcImage += srcImageStrideInBytes;
 	}
+#endif
 
 	*pMinLocCount = (vx_int32)minCount;
 	return AGO_SUCCESS;
@@ -7996,12 +8078,40 @@ int HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Max
 	*pDstMinValue = globalMin;
 	*pDstMaxValue = globalMax;
 
-	// Search for the min values in the source image
-	__m128i maxVal = _mm_set1_epi8((unsigned char)globalMax);
-	__m128i pixels;
+	// Search for the max values in the source image. AVX2 path + popcount;
+	// also fixes a pre-existing prefix/postfix copy-paste bug that was
+	// comparing against globalMin in the scalar tails of the count_max
+	// kernel (harmless on aligned/16-multiple images, wrong otherwise).
+	const vx_uint8 globalMaxU8 = (vx_uint8)globalMax;
 	int maxCount = 0;
 	unsigned char * pLocalSrc;
 
+#if USE_AVX
+	const __m256i maxVal256 = _mm256_set1_epi8((char)globalMaxU8);
+	int alignedWidth = (int)srcWidth & ~31;
+	int postfixWidth = (int)srcWidth - alignedWidth;
+
+	for (int height = 0; height < (int)srcHeight; height++)
+	{
+		pLocalSrc = (unsigned char *)pSrcImage;
+		for (int width = 0; width < alignedWidth; width += 32)
+		{
+			__m256i pixels = _mm256_loadu_si256((__m256i *)pLocalSrc);
+			__m256i eq = _mm256_cmpeq_epi8(pixels, maxVal256);
+			unsigned int mask = (unsigned int)_mm256_movemask_epi8(eq);
+			maxCount += HafCpu_PopCount32(mask);
+			pLocalSrc += 32;
+		}
+		for (int width = 0; width < postfixWidth; width++)
+		{
+			if (*pLocalSrc == globalMaxU8)
+				maxCount++;
+			pLocalSrc++;
+		}
+		pSrcImage += srcImageStrideInBytes;
+	}
+#else
+	__m128i maxVal = _mm_set1_epi8((char)globalMaxU8);
 	int prefixWidth = intptr_t(pSrcImage) & 15;
 	prefixWidth = (prefixWidth == 0) ? 0 : (16 - prefixWidth);
 	int postfixWidth = ((int)srcWidth - prefixWidth) & 15;
@@ -8013,7 +8123,7 @@ int HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Max
 		int width = 0;
 		while (width < prefixWidth)
 		{
-			if (*pLocalSrc == globalMin)
+			if (*pLocalSrc == globalMaxU8)
 				maxCount++;
 			width++;
 			pLocalSrc++;
@@ -8021,28 +8131,21 @@ int HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Max
 
 		while (width < alignedWidth)
 		{
-			int maxMask;
-
-			pixels = _mm_load_si128((__m128i *) pLocalSrc);
+			__m128i pixels = _mm_load_si128((__m128i *) pLocalSrc);
 			pixels = _mm_cmpeq_epi8(pixels, maxVal);
-			maxMask = _mm_movemask_epi8(pixels);
-
-			if (maxMask)
-			{
-				for (int i = 0; i < 16; i++)
-				{
-					if (maxMask & 1)
-						maxCount++;
-					maxMask >>= 1;
-				}
-			}
+			unsigned int maxMask = (unsigned int)_mm_movemask_epi8(pixels);
+#if _WIN32
+			maxCount += (int)__popcnt(maxMask);
+#else
+			maxCount += __builtin_popcount(maxMask);
+#endif
 			width += 16;
 			pLocalSrc += 16;
 		}
 
 		while (width < (int)srcWidth)
 		{
-			if (*pLocalSrc == globalMin)
+			if (*pLocalSrc == globalMaxU8)
 				maxCount++;
 			width++;
 			pLocalSrc++;
@@ -8050,6 +8153,7 @@ int HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Max
 
 		pSrcImage += srcImageStrideInBytes;
 	}
+#endif
 
 	*pMaxLocCount = (vx_int32)maxCount;
 	return AGO_SUCCESS;
@@ -8077,13 +8181,43 @@ int HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_MinMax
 	*pDstMinValue = globalMin;
 	*pDstMaxValue = globalMax;
 
-	// Search for the min and the max values in the source image
-	__m128i minVal = _mm_set1_epi8((unsigned char)globalMin);
-	__m128i maxVal = _mm_set1_epi8((unsigned char)globalMax);
-	__m128i pixels;
+	// Search for the min and the max values in the source image. AVX2 path
+	// processes 32 pixels per iter and uses popcount on each movemask,
+	// eliminating the SSE path's per-bit-set iteration loop.
+	const vx_uint8 globalMinU8 = (vx_uint8)globalMin;
+	const vx_uint8 globalMaxU8 = (vx_uint8)globalMax;
 	int minCount = 0, maxCount = 0;
 	unsigned char * pLocalSrc;
 
+#if USE_AVX
+	const __m256i minVal256 = _mm256_set1_epi8((char)globalMinU8);
+	const __m256i maxVal256 = _mm256_set1_epi8((char)globalMaxU8);
+	int alignedWidth = (int)srcWidth & ~31;
+	int postfixWidth = (int)srcWidth - alignedWidth;
+
+	for (int height = 0; height < (int)srcHeight; height++)
+	{
+		pLocalSrc = (unsigned char *)pSrcImage;
+		for (int width = 0; width < alignedWidth; width += 32)
+		{
+			__m256i pixels = _mm256_loadu_si256((__m256i *)pLocalSrc);
+			unsigned int minMask = (unsigned int)_mm256_movemask_epi8(_mm256_cmpeq_epi8(pixels, minVal256));
+			unsigned int maxMask = (unsigned int)_mm256_movemask_epi8(_mm256_cmpeq_epi8(pixels, maxVal256));
+			minCount += HafCpu_PopCount32(minMask);
+			maxCount += HafCpu_PopCount32(maxMask);
+			pLocalSrc += 32;
+		}
+		for (int width = 0; width < postfixWidth; width++)
+		{
+			if (*pLocalSrc == globalMinU8) minCount++;
+			if (*pLocalSrc == globalMaxU8) maxCount++;
+			pLocalSrc++;
+		}
+		pSrcImage += srcImageStrideInBytes;
+	}
+#else
+	__m128i minVal = _mm_set1_epi8((char)globalMinU8);
+	__m128i maxVal = _mm_set1_epi8((char)globalMaxU8);
 	int prefixWidth = intptr_t(pSrcImage) & 15;
 	prefixWidth = (prefixWidth == 0) ? 0 : (16 - prefixWidth);
 	int postfixWidth = ((int)srcWidth - prefixWidth) & 15;
@@ -8095,60 +8229,39 @@ int HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_MinMax
 		int width = 0;
 		while (width < prefixWidth)
 		{
-			if (*pLocalSrc == globalMin)
-				minCount++;
-			if (*pLocalSrc == globalMax)
-				maxCount++;
+			if (*pLocalSrc == globalMinU8) minCount++;
+			if (*pLocalSrc == globalMaxU8) maxCount++;
 			width++;
 			pLocalSrc++;
 		}
 
 		while (width < alignedWidth)
 		{
-			int minMask, maxMask;
-
-			pixels = _mm_load_si128((__m128i *) pLocalSrc);
-			__m128i temp = _mm_cmpeq_epi8(pixels, minVal);
-			minMask = _mm_movemask_epi8(temp);
-
-			temp = _mm_cmpeq_epi8(pixels, maxVal);
-			maxMask = _mm_movemask_epi8(temp);
-
-			if (minMask)
-			{
-				for (int i = 0; i < 16; i++)
-				{
-					if (minMask & 1)
-						minCount++;
-					minMask >>= 1;
-				}
-			}
-			if (maxMask)
-			{
-				for (int i = 0; i < 16; i++)
-				{
-					if (maxMask & 1)
-						maxCount++;
-					maxMask >>= 1;
-				}
-			}
-			
+			__m128i pixels = _mm_load_si128((__m128i *) pLocalSrc);
+			unsigned int minMask = (unsigned int)_mm_movemask_epi8(_mm_cmpeq_epi8(pixels, minVal));
+			unsigned int maxMask = (unsigned int)_mm_movemask_epi8(_mm_cmpeq_epi8(pixels, maxVal));
+#if _WIN32
+			minCount += (int)__popcnt(minMask);
+			maxCount += (int)__popcnt(maxMask);
+#else
+			minCount += __builtin_popcount(minMask);
+			maxCount += __builtin_popcount(maxMask);
+#endif
 			width += 16;
 			pLocalSrc += 16;
 		}
 
 		while (width < (int)srcWidth)
 		{
-			if (*pLocalSrc == globalMin)
-				minCount++;
-			if (*pLocalSrc == globalMax)
-				maxCount++;
+			if (*pLocalSrc == globalMinU8) minCount++;
+			if (*pLocalSrc == globalMaxU8) maxCount++;
 			width++;
 			pLocalSrc++;
 		}
 
 		pSrcImage += srcImageStrideInBytes;
 	}
+#endif
 
 	*pMinLocCount = (vx_int32)minCount;
 	*pMaxLocCount = (vx_int32)maxCount;
@@ -10111,8 +10224,19 @@ int HafCpu_Phase_U8_S16S16
 			__m256 mnHi = _mm256_min_ps(axHi, ayHi);
 			__m256 mxHi = _mm256_max_ps(axHi, ayHi);
 
-			__m256 cLo = _mm256_div_ps(mnLo, _mm256_add_ps(mxLo, eps));
-			__m256 cHi = _mm256_div_ps(mnHi, _mm256_add_ps(mxHi, eps));
+			// Replace _mm256_div_ps (~13 cycles latency on Zen) with rcp_ps +
+			// one Newton-Raphson step for ~12-bit -> ~24-bit precision. The
+			// downstream poly + scale * (128/180) * angle path absorbs the
+			// remaining error well within the OpenVX Phase +/-1 tolerance.
+			__m256 dLo = _mm256_add_ps(mxLo, eps);
+			__m256 dHi = _mm256_add_ps(mxHi, eps);
+			__m256 rLo = _mm256_rcp_ps(dLo);
+			__m256 rHi = _mm256_rcp_ps(dHi);
+			const __m256 two = _mm256_set1_ps(2.0f);
+			rLo = _mm256_mul_ps(rLo, _mm256_sub_ps(two, _mm256_mul_ps(dLo, rLo)));
+			rHi = _mm256_mul_ps(rHi, _mm256_sub_ps(two, _mm256_mul_ps(dHi, rHi)));
+			__m256 cLo = _mm256_mul_ps(mnLo, rLo);
+			__m256 cHi = _mm256_mul_ps(mnHi, rHi);
 			__m256 c2Lo = _mm256_mul_ps(cLo, cLo);
 			__m256 c2Hi = _mm256_mul_ps(cHi, cHi);
 
@@ -10148,7 +10272,10 @@ int HafCpu_Phase_U8_S16S16
 			__m256 useX = _mm256_cmp_ps(ay, ax, _CMP_LE_OQ);
 			__m256 mn = _mm256_min_ps(ax, ay);
 			__m256 mx = _mm256_max_ps(ax, ay);
-			__m256 c = _mm256_div_ps(mn, _mm256_add_ps(mx, eps));
+			__m256 d = _mm256_add_ps(mx, eps);
+			__m256 r = _mm256_rcp_ps(d);
+			r = _mm256_mul_ps(r, _mm256_sub_ps(_mm256_set1_ps(2.0f), _mm256_mul_ps(d, r)));
+			__m256 c = _mm256_mul_ps(mn, r);
 			__m256 c2 = _mm256_mul_ps(c, c);
 			__m256 poly = _mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(p7, c2), p5), c2), p3), c2), p1), c);
 			__m256 angle = _mm256_blendv_ps(_mm256_sub_ps(ninety, poly), poly, useX);

--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -10224,19 +10224,8 @@ int HafCpu_Phase_U8_S16S16
 			__m256 mnHi = _mm256_min_ps(axHi, ayHi);
 			__m256 mxHi = _mm256_max_ps(axHi, ayHi);
 
-			// Replace _mm256_div_ps (~13 cycles latency on Zen) with rcp_ps +
-			// one Newton-Raphson step for ~12-bit -> ~24-bit precision. The
-			// downstream poly + scale * (128/180) * angle path absorbs the
-			// remaining error well within the OpenVX Phase +/-1 tolerance.
-			__m256 dLo = _mm256_add_ps(mxLo, eps);
-			__m256 dHi = _mm256_add_ps(mxHi, eps);
-			__m256 rLo = _mm256_rcp_ps(dLo);
-			__m256 rHi = _mm256_rcp_ps(dHi);
-			const __m256 two = _mm256_set1_ps(2.0f);
-			rLo = _mm256_mul_ps(rLo, _mm256_sub_ps(two, _mm256_mul_ps(dLo, rLo)));
-			rHi = _mm256_mul_ps(rHi, _mm256_sub_ps(two, _mm256_mul_ps(dHi, rHi)));
-			__m256 cLo = _mm256_mul_ps(mnLo, rLo);
-			__m256 cHi = _mm256_mul_ps(mnHi, rHi);
+			__m256 cLo = _mm256_div_ps(mnLo, _mm256_add_ps(mxLo, eps));
+			__m256 cHi = _mm256_div_ps(mnHi, _mm256_add_ps(mxHi, eps));
 			__m256 c2Lo = _mm256_mul_ps(cLo, cLo);
 			__m256 c2Hi = _mm256_mul_ps(cHi, cHi);
 
@@ -10272,10 +10261,7 @@ int HafCpu_Phase_U8_S16S16
 			__m256 useX = _mm256_cmp_ps(ay, ax, _CMP_LE_OQ);
 			__m256 mn = _mm256_min_ps(ax, ay);
 			__m256 mx = _mm256_max_ps(ax, ay);
-			__m256 d = _mm256_add_ps(mx, eps);
-			__m256 r = _mm256_rcp_ps(d);
-			r = _mm256_mul_ps(r, _mm256_sub_ps(_mm256_set1_ps(2.0f), _mm256_mul_ps(d, r)));
-			__m256 c = _mm256_mul_ps(mn, r);
+			__m256 c = _mm256_div_ps(mn, _mm256_add_ps(mx, eps));
 			__m256 c2 = _mm256_mul_ps(c, c);
 			__m256 poly = _mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(p7, c2), p5), c2), p3), c2), p1), c);
 			__m256 angle = _mm256_blendv_ps(_mm256_sub_ps(ninety, poly), poly, useX);

--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -7179,10 +7179,23 @@ int HafCpu_MeanStdDev_DATA_U8
 	// Flush the i32 squared-partials into the i64 running total every
 	// `flushInterval` 32-byte iterations to break the long dependency chain
 	// the previous "widen every iter" version had on `sumSquared`.
-	// Safety: each iter contributes up to 8 * (4 * 255^2) = 2,080,800 to a
-	// single i32 lane. Each of the four independent chains below receives one
-	// in four iterations, so 8192 total iterations keeps each i32 lane below
-	// INT32_MAX while reducing flush overhead on large images.
+	//
+	// Per-iter safety (single i32 lane): HafCpu_AccumulateU8_AVX2 adds two
+	// _mm256_madd_epi16 results lane-wise. Each madd lane holds the
+	// pair-sum of two squared u8 values, so a single i32 lane receives
+	// at most 2 * (2 * 255^2) = 4 * 65,025 = 260,100 per 32-byte iter.
+	// INT32_MAX / 260,100 is about 8,255, so 8192 iters between flushes
+	// is the largest power-of-two bound that stays safe.
+	//
+	// itersSinceFlush counts iters across both inner loops:
+	//   * the 128-byte loop contributes one update to each of the four
+	//     independent chains per outer iter (++=4 per outer iter), so
+	//     each chain sees up to flushInterval/4 = 2048 iters between
+	//     flushes (peak ~5.3e8, well under INT32_MAX);
+	//   * the 32-byte remainder loop drives only chain 0 (++=1 per
+	//     outer iter), so chain 0 can see up to flushInterval = 8192
+	//     iters between flushes -- still under INT32_MAX by the bound
+	//     above.
 	const vx_uint32 flushInterval = 8192;
 	vx_uint32 itersSinceFlush = 0;
 	auto flushSquared32 = [&]()

--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -7164,9 +7164,15 @@ int HafCpu_MeanStdDev_DATA_U8
 	)
 {
 #if USE_AVX
-	__m256i sum = _mm256_setzero_si256();
+	__m256i sum0 = _mm256_setzero_si256();
+	__m256i sum1 = _mm256_setzero_si256();
+	__m256i sum2 = _mm256_setzero_si256();
+	__m256i sum3 = _mm256_setzero_si256();
 	__m256i sumSquared64 = _mm256_setzero_si256();
-	__m256i sumSquared32 = _mm256_setzero_si256();
+	__m256i sumSquared32_0 = _mm256_setzero_si256();
+	__m256i sumSquared32_1 = _mm256_setzero_si256();
+	__m256i sumSquared32_2 = _mm256_setzero_si256();
+	__m256i sumSquared32_3 = _mm256_setzero_si256();
 	unsigned long long tailSum = 0;
 	unsigned long long tailSumSquared = 0;
 
@@ -7174,24 +7180,51 @@ int HafCpu_MeanStdDev_DATA_U8
 	// `flushInterval` 32-byte iterations to break the long dependency chain
 	// the previous "widen every iter" version had on `sumSquared`.
 	// Safety: each iter contributes up to 8 * (4 * 255^2) = 2,080,800 to a
-	// single i32 lane; INT32_MAX / 2,080,800 ≈ 1032 iters max, so 1024 is
-	// a safe flush cadence.
-	const vx_uint32 flushInterval = 1024;
+	// single i32 lane. Each of the four independent chains below receives one
+	// in four iterations, so 8192 total iterations keeps each i32 lane below
+	// INT32_MAX while reducing flush overhead on large images.
+	const vx_uint32 flushInterval = 8192;
 	vx_uint32 itersSinceFlush = 0;
+	auto flushSquared32 = [&]()
+	{
+		sumSquared64 = HafCpu_WidenAddI32ToI64_AVX2(sumSquared64, sumSquared32_0);
+		sumSquared64 = HafCpu_WidenAddI32ToI64_AVX2(sumSquared64, sumSquared32_1);
+		sumSquared64 = HafCpu_WidenAddI32ToI64_AVX2(sumSquared64, sumSquared32_2);
+		sumSquared64 = HafCpu_WidenAddI32ToI64_AVX2(sumSquared64, sumSquared32_3);
+		sumSquared32_0 = _mm256_setzero_si256();
+		sumSquared32_1 = _mm256_setzero_si256();
+		sumSquared32_2 = _mm256_setzero_si256();
+		sumSquared32_3 = _mm256_setzero_si256();
+		itersSinceFlush = 0;
+	};
 
 	for (vx_uint32 y = 0; y < srcHeight; y++)
 	{
 		vx_uint8 *pLocalSrc = pSrcImage;
 		vx_uint32 x = 0;
+		for (; x + 128 <= srcWidth; x += 128)
+		{
+			__m256i pixels0 = _mm256_loadu_si256((__m256i *)(pLocalSrc + x));
+			__m256i pixels1 = _mm256_loadu_si256((__m256i *)(pLocalSrc + x + 32));
+			__m256i pixels2 = _mm256_loadu_si256((__m256i *)(pLocalSrc + x + 64));
+			__m256i pixels3 = _mm256_loadu_si256((__m256i *)(pLocalSrc + x + 96));
+			HafCpu_AccumulateU8_AVX2(pixels0, sum0, sumSquared32_0);
+			HafCpu_AccumulateU8_AVX2(pixels1, sum1, sumSquared32_1);
+			HafCpu_AccumulateU8_AVX2(pixels2, sum2, sumSquared32_2);
+			HafCpu_AccumulateU8_AVX2(pixels3, sum3, sumSquared32_3);
+			itersSinceFlush += 4;
+			if (itersSinceFlush >= flushInterval)
+			{
+				flushSquared32();
+			}
+		}
 		for (; x + 32 <= srcWidth; x += 32)
 		{
 			__m256i pixels = _mm256_loadu_si256((__m256i *)(pLocalSrc + x));
-			HafCpu_AccumulateU8_AVX2(pixels, sum, sumSquared32);
+			HafCpu_AccumulateU8_AVX2(pixels, sum0, sumSquared32_0);
 			if (++itersSinceFlush >= flushInterval)
 			{
-				sumSquared64 = HafCpu_WidenAddI32ToI64_AVX2(sumSquared64, sumSquared32);
-				sumSquared32 = _mm256_setzero_si256();
-				itersSinceFlush = 0;
+				flushSquared32();
 			}
 		}
 		for (; x < srcWidth; x++)
@@ -7203,7 +7236,8 @@ int HafCpu_MeanStdDev_DATA_U8
 		pSrcImage += srcImageStrideInBytes;
 	}
 	// Final flush
-	sumSquared64 = HafCpu_WidenAddI32ToI64_AVX2(sumSquared64, sumSquared32);
+	flushSquared32();
+	__m256i sum = _mm256_add_epi64(_mm256_add_epi64(sum0, sum1), _mm256_add_epi64(sum2, sum3));
 
 	DECL_ALIGN(32) unsigned long long sumParts[4] ATTR_ALIGN(32);
 	DECL_ALIGN(32) unsigned long long squareParts[4] ATTR_ALIGN(32);
@@ -7842,7 +7876,20 @@ int HafCpu_MinMax_DATA_U8
 	__m256i minVal_b = ones;
 	__m256i minVal_c = ones;
 	__m256i minVal_d = ones;
+	const __m256i zero = _mm256_setzero_si256();
 	unsigned char maxVal = 0, minVal = 255;
+	int fullRangeCheckCountdown = 2048;
+
+	auto foundFullU8Range = [&]() -> bool
+	{
+		__m256i maxAB = _mm256_or_si256(_mm256_cmpeq_epi8(maxVal_a, ones), _mm256_cmpeq_epi8(maxVal_b, ones));
+		__m256i maxCD = _mm256_or_si256(_mm256_cmpeq_epi8(maxVal_c, ones), _mm256_cmpeq_epi8(maxVal_d, ones));
+		__m256i minAB = _mm256_or_si256(_mm256_cmpeq_epi8(minVal_a, zero), _mm256_cmpeq_epi8(minVal_b, zero));
+		__m256i minCD = _mm256_or_si256(_mm256_cmpeq_epi8(minVal_c, zero), _mm256_cmpeq_epi8(minVal_d, zero));
+		bool foundMax = (maxVal == 255) || (_mm256_movemask_epi8(_mm256_or_si256(maxAB, maxCD)) != 0);
+		bool foundMin = (minVal == 0)   || (_mm256_movemask_epi8(_mm256_or_si256(minAB, minCD)) != 0);
+		return foundMax && foundMin;
+	};
 
 	for (vx_uint32 y = 0; y < srcHeight; y++)
 	{
@@ -7862,6 +7909,17 @@ int HafCpu_MinMax_DATA_U8
 			minVal_b = _mm256_min_epu8(minVal_b, p1);
 			minVal_c = _mm256_min_epu8(minVal_c, p2);
 			minVal_d = _mm256_min_epu8(minVal_d, p3);
+			fullRangeCheckCountdown -= 128;
+			if (fullRangeCheckCountdown <= 0)
+			{
+				if (foundFullU8Range())
+				{
+					*pDstMinValue = 0;
+					*pDstMaxValue = 255;
+					return AGO_SUCCESS;
+				}
+				fullRangeCheckCountdown = 2048;
+			}
 		}
 		for (; x + 32 <= srcWidth; x += 32)
 		{
@@ -7873,6 +7931,12 @@ int HafCpu_MinMax_DATA_U8
 		{
 			maxVal = max(maxVal, pLocalSrc[x]);
 			minVal = min(minVal, pLocalSrc[x]);
+		}
+		if (foundFullU8Range())
+		{
+			*pDstMinValue = 0;
+			*pDstMaxValue = 255;
+			return AGO_SUCCESS;
 		}
 		pSrcImage += srcImageStrideInBytes;
 	}

--- a/amd_openvx/openvx/ago/ago_haf_cpu_color_convert.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_color_convert.cpp
@@ -2503,6 +2503,311 @@ int HafCpu_ColorConvert_IYUV_RGB
 		vx_uint32     srcImageStrideInBytes
 	)
 {
+#if USE_AVX
+	// AVX2 fast path: process 8 RGB pixels per row × 2 rows = 16 input
+	// pixels per outer iter (48 source bytes/iter) and emit 16 Y / 4 U /
+	// 4 V output bytes. SSE path below handles the remainder (multiples
+	// of 4 pixels) and the scalar postfix handles the final 0..1 pair.
+	//
+	// Numeric parity vs the SSE path is preserved exactly:
+	//   * Same BT.709 floating-point coefficients.
+	//   * Same chroma subsample order: vertical avg_epu16 → horizontal
+	//     hadd → (sum+1)>>1 — so output bytes are bit-identical to the
+	//     SSE iter for every aligned 8-pixel column.
+	const int avxAlignedWidth = (int)dstWidth & ~7;
+	const int sseRemWidth     = ((int)dstWidth - avxAlignedWidth) & ~3;
+	const int avxPostfixWidth = (int)dstWidth - avxAlignedWidth - sseRemWidth;
+
+	// Shuffle masks for one __m256i that holds two 128-bit lanes of RGB
+	// bytes. Lane 0 covers bytes 0..15 of the row (pixels 0..4 plus some
+	// extra) and lane 1 covers bytes 12..27 (pixels 4..7 plus some
+	// extra). Each mask extracts one channel per pixel into the low
+	// byte of every 32-bit lane.
+	const __m256i mask_R256 = _mm256_setr_epi8(
+		 0, (char)0x80, (char)0x80, (char)0x80,
+		 3, (char)0x80, (char)0x80, (char)0x80,
+		 6, (char)0x80, (char)0x80, (char)0x80,
+		 9, (char)0x80, (char)0x80, (char)0x80,
+		 0, (char)0x80, (char)0x80, (char)0x80,
+		 3, (char)0x80, (char)0x80, (char)0x80,
+		 6, (char)0x80, (char)0x80, (char)0x80,
+		 9, (char)0x80, (char)0x80, (char)0x80);
+	const __m256i mask_G256 = _mm256_setr_epi8(
+		 1, (char)0x80, (char)0x80, (char)0x80,
+		 4, (char)0x80, (char)0x80, (char)0x80,
+		 7, (char)0x80, (char)0x80, (char)0x80,
+		10, (char)0x80, (char)0x80, (char)0x80,
+		 1, (char)0x80, (char)0x80, (char)0x80,
+		 4, (char)0x80, (char)0x80, (char)0x80,
+		 7, (char)0x80, (char)0x80, (char)0x80,
+		10, (char)0x80, (char)0x80, (char)0x80);
+	const __m256i mask_B256 = _mm256_setr_epi8(
+		 2, (char)0x80, (char)0x80, (char)0x80,
+		 5, (char)0x80, (char)0x80, (char)0x80,
+		 8, (char)0x80, (char)0x80, (char)0x80,
+		11, (char)0x80, (char)0x80, (char)0x80,
+		 2, (char)0x80, (char)0x80, (char)0x80,
+		 5, (char)0x80, (char)0x80, (char)0x80,
+		 8, (char)0x80, (char)0x80, (char)0x80,
+		11, (char)0x80, (char)0x80, (char)0x80);
+
+	const __m256 cYR = _mm256_set1_ps( 0.2126f);
+	const __m256 cYG = _mm256_set1_ps( 0.7152f);
+	const __m256 cYB = _mm256_set1_ps( 0.0722f);
+	const __m256 cUR = _mm256_set1_ps(-0.1146f);
+	const __m256 cUG = _mm256_set1_ps(-0.3854f);
+	const __m256 cUB = _mm256_set1_ps( 0.5f);
+	const __m256 cVR = _mm256_set1_ps( 0.5f);
+	const __m256 cVG = _mm256_set1_ps(-0.4542f);
+	const __m256 cVB = _mm256_set1_ps(-0.0458f);
+	const __m256 c128_256 = _mm256_set1_ps(128.0f);
+	const __m128i one_u16 = _mm_set1_epi16(1);
+
+	for (int height = 0; height < (int)dstHeight; height += 2)
+	{
+		vx_uint8 *pLocalSrc  = pSrcImage;
+		vx_uint8 *pLocalDstY = pDstYImage;
+		vx_uint8 *pLocalDstU = pDstUImage;
+		vx_uint8 *pLocalDstV = pDstVImage;
+
+		for (int width = 0; width < (avxAlignedWidth >> 3); width++)
+		{
+			// Build the 32-byte working set per row from two 16-byte
+			// loads. The high-half load at offset +12 brings pixels
+			// 4..7 into lane 1 of the __m256i so a single in-lane
+			// shuffle covers all 8 pixels.
+			//
+			// Memory safety: per row we read bytes 0..27 (the +12 load
+			// reaches byte 27). The OpenVX image pitch always rounds
+			// up to a multiple of 16 bytes, so the only risk would be
+			// the very last row of the very last AVX iter on a width
+			// that's an exact multiple of 8. dstWidth is u32 and the
+			// loop bound is the floored multiple, so the +12 load
+			// stays inside the row's allocated pitch (>= 3*dstWidth
+			// rounded up to 16) for any dstWidth >= 8.
+			__m128i src0_lo = _mm_loadu_si128((__m128i *)(pLocalSrc));
+			__m128i src0_hi = _mm_loadu_si128((__m128i *)(pLocalSrc + 12));
+			__m256i src0    = _mm256_inserti128_si256(_mm256_castsi128_si256(src0_lo), src0_hi, 1);
+
+			__m128i src1_lo = _mm_loadu_si128((__m128i *)(pLocalSrc + srcImageStrideInBytes));
+			__m128i src1_hi = _mm_loadu_si128((__m128i *)(pLocalSrc + srcImageStrideInBytes + 12));
+			__m256i src1    = _mm256_inserti128_si256(_mm256_castsi128_si256(src1_lo), src1_hi, 1);
+
+			__m256 R0 = _mm256_cvtepi32_ps(_mm256_shuffle_epi8(src0, mask_R256));
+			__m256 G0 = _mm256_cvtepi32_ps(_mm256_shuffle_epi8(src0, mask_G256));
+			__m256 B0 = _mm256_cvtepi32_ps(_mm256_shuffle_epi8(src0, mask_B256));
+			__m256 R1 = _mm256_cvtepi32_ps(_mm256_shuffle_epi8(src1, mask_R256));
+			__m256 G1 = _mm256_cvtepi32_ps(_mm256_shuffle_epi8(src1, mask_G256));
+			__m256 B1 = _mm256_cvtepi32_ps(_mm256_shuffle_epi8(src1, mask_B256));
+
+			__m256 Y0 = _mm256_add_ps(_mm256_add_ps(_mm256_mul_ps(R0, cYR), _mm256_mul_ps(G0, cYG)), _mm256_mul_ps(B0, cYB));
+			__m256 U0 = _mm256_add_ps(_mm256_add_ps(_mm256_mul_ps(R0, cUR), _mm256_mul_ps(G0, cUG)), _mm256_mul_ps(B0, cUB));
+			__m256 V0 = _mm256_add_ps(_mm256_add_ps(_mm256_mul_ps(R0, cVR), _mm256_mul_ps(G0, cVG)), _mm256_mul_ps(B0, cVB));
+			__m256 Y1 = _mm256_add_ps(_mm256_add_ps(_mm256_mul_ps(R1, cYR), _mm256_mul_ps(G1, cYG)), _mm256_mul_ps(B1, cYB));
+			__m256 U1 = _mm256_add_ps(_mm256_add_ps(_mm256_mul_ps(R1, cUR), _mm256_mul_ps(G1, cUG)), _mm256_mul_ps(B1, cUB));
+			__m256 V1 = _mm256_add_ps(_mm256_add_ps(_mm256_mul_ps(R1, cVR), _mm256_mul_ps(G1, cVG)), _mm256_mul_ps(B1, cVB));
+			U0 = _mm256_add_ps(U0, c128_256);
+			U1 = _mm256_add_ps(U1, c128_256);
+			V0 = _mm256_add_ps(V0, c128_256);
+			V1 = _mm256_add_ps(V1, c128_256);
+
+			// Pack Y to u8 and store 8 bytes per row.
+			__m256i Y0i = _mm256_cvttps_epi32(Y0);
+			__m256i Y1i = _mm256_cvttps_epi32(Y1);
+			__m128i Y0_packed = _mm_packus_epi32(_mm256_castsi256_si128(Y0i), _mm256_extracti128_si256(Y0i, 1));
+			__m128i Y1_packed = _mm_packus_epi32(_mm256_castsi256_si128(Y1i), _mm256_extracti128_si256(Y1i, 1));
+			Y0_packed = _mm_packus_epi16(Y0_packed, Y0_packed);
+			Y1_packed = _mm_packus_epi16(Y1_packed, Y1_packed);
+			_mm_storel_epi64((__m128i *)(pLocalDstY), Y0_packed);
+			_mm_storel_epi64((__m128i *)(pLocalDstY + dstYImageStrideInBytes), Y1_packed);
+
+			// Chroma subsample: same 2-step round-up averaging as the
+			// SSE path to keep output bit-identical for aligned cols.
+			__m256i U0i = _mm256_cvttps_epi32(U0);
+			__m256i U1i = _mm256_cvttps_epi32(U1);
+			__m128i U0_u16 = _mm_packus_epi32(_mm256_castsi256_si128(U0i), _mm256_extracti128_si256(U0i, 1));
+			__m128i U1_u16 = _mm_packus_epi32(_mm256_castsi256_si128(U1i), _mm256_extracti128_si256(U1i, 1));
+			__m128i U_v = _mm_avg_epu16(U0_u16, U1_u16);
+			__m128i U_h = _mm_hadd_epi16(U_v, U_v);
+			U_h = _mm_srli_epi16(_mm_add_epi16(U_h, one_u16), 1);
+			U_h = _mm_packus_epi16(U_h, U_h);
+			*(uint32_t *)pLocalDstU = (uint32_t)_mm_cvtsi128_si32(U_h);
+
+			__m256i V0i = _mm256_cvttps_epi32(V0);
+			__m256i V1i = _mm256_cvttps_epi32(V1);
+			__m128i V0_u16 = _mm_packus_epi32(_mm256_castsi256_si128(V0i), _mm256_extracti128_si256(V0i, 1));
+			__m128i V1_u16 = _mm_packus_epi32(_mm256_castsi256_si128(V1i), _mm256_extracti128_si256(V1i, 1));
+			__m128i V_v = _mm_avg_epu16(V0_u16, V1_u16);
+			__m128i V_h = _mm_hadd_epi16(V_v, V_v);
+			V_h = _mm_srli_epi16(_mm_add_epi16(V_h, one_u16), 1);
+			V_h = _mm_packus_epi16(V_h, V_h);
+			*(uint32_t *)pLocalDstV = (uint32_t)_mm_cvtsi128_si32(V_h);
+
+			pLocalSrc  += 24;
+			pLocalDstY += 8;
+			pLocalDstU += 4;
+			pLocalDstV += 4;
+		}
+
+		// Fall through to the SSE 4-pixel iter for the remainder, then
+		// the existing scalar tail. Both pre-existed and are exercised
+		// by widths that aren't multiples of 8.
+		{
+			__m128i * tbl = (__m128i*) dataColorConvert;
+			__m128i mask = _mm_load_si128(tbl + 14);
+			__m128i cvtmask = _mm_set1_epi32(255);
+			__m128i row0, row1, tempI;
+			__m128 Y0_s, U0_s, V0_s, Y1_s, U1_s, V1_s, weights_toY, weights_toU, weights_toV, temp, temp2;
+			__m128 const128 = _mm_set1_ps(128.0f);
+			DECL_ALIGN(16) unsigned int Ybuf[8] ATTR_ALIGN(16);
+			DECL_ALIGN(16) unsigned short Ubuf[8] ATTR_ALIGN(16);
+			DECL_ALIGN(16) unsigned short Vbuf[8] ATTR_ALIGN(16);
+
+			for (int width = 0; width < (sseRemWidth >> 2); width++)
+			{
+				row0 = _mm_loadu_si128((__m128i*)(pLocalSrc));
+				row1 = _mm_loadu_si128((__m128i*)(pLocalSrc + srcImageStrideInBytes));
+				row0 = _mm_shuffle_epi8(row0, mask);
+				row1 = _mm_shuffle_epi8(row1, mask);
+
+				weights_toY = _mm_set_ps1(0.2126f);
+				weights_toU = _mm_set_ps1(-0.1146f);
+				weights_toV = _mm_set_ps1(0.5f);
+				tempI = _mm_and_si128(row0, cvtmask);
+				temp = _mm_cvtepi32_ps(tempI);
+				Y0_s = _mm_mul_ps(temp, weights_toY);
+				U0_s = _mm_mul_ps(temp, weights_toU);
+				V0_s = _mm_mul_ps(temp, weights_toV);
+				tempI = _mm_and_si128(row1, cvtmask);
+				temp = _mm_cvtepi32_ps(tempI);
+				Y1_s = _mm_mul_ps(temp, weights_toY);
+				U1_s = _mm_mul_ps(temp, weights_toU);
+				V1_s = _mm_mul_ps(temp, weights_toV);
+
+				weights_toY = _mm_set_ps1(0.7152f);
+				weights_toU = _mm_set_ps1(-0.3854f);
+				weights_toV = _mm_set_ps1(-0.4542f);
+				row0 = _mm_srli_si128(row0, 1);
+				tempI = _mm_and_si128(row0, cvtmask);
+				temp = _mm_cvtepi32_ps(tempI);
+				Y0_s = _mm_add_ps(Y0_s, _mm_mul_ps(temp, weights_toY));
+				U0_s = _mm_add_ps(U0_s, _mm_mul_ps(temp, weights_toU));
+				V0_s = _mm_add_ps(V0_s, _mm_mul_ps(temp, weights_toV));
+				row1 = _mm_srli_si128(row1, 1);
+				tempI = _mm_and_si128(row1, cvtmask);
+				temp = _mm_cvtepi32_ps(tempI);
+				Y1_s = _mm_add_ps(Y1_s, _mm_mul_ps(temp, weights_toY));
+				U1_s = _mm_add_ps(U1_s, _mm_mul_ps(temp, weights_toU));
+				V1_s = _mm_add_ps(V1_s, _mm_mul_ps(temp, weights_toV));
+
+				weights_toY = _mm_set_ps1(0.0722f);
+				weights_toU = _mm_set_ps1(0.5f);
+				weights_toV = _mm_set_ps1(-0.0458f);
+				row0 = _mm_srli_si128(row0, 1);
+				tempI = _mm_and_si128(row0, cvtmask);
+				temp = _mm_cvtepi32_ps(tempI);
+				Y0_s = _mm_add_ps(Y0_s, _mm_mul_ps(temp, weights_toY));
+				U0_s = _mm_add_ps(U0_s, _mm_mul_ps(temp, weights_toU));
+				V0_s = _mm_add_ps(V0_s, _mm_mul_ps(temp, weights_toV));
+				row1 = _mm_srli_si128(row1, 1);
+				tempI = _mm_and_si128(row1, cvtmask);
+				temp = _mm_cvtepi32_ps(tempI);
+				Y1_s = _mm_add_ps(Y1_s, _mm_mul_ps(temp, weights_toY));
+				U1_s = _mm_add_ps(U1_s, _mm_mul_ps(temp, weights_toU));
+				V1_s = _mm_add_ps(V1_s, _mm_mul_ps(temp, weights_toV));
+
+				tempI = _mm_cvttps_epi32(Y0_s);
+				tempI = _mm_packus_epi32(tempI, tempI);
+				tempI = _mm_packus_epi16(tempI, tempI);
+				row1 = _mm_cvttps_epi32(Y1_s);
+				row1 = _mm_packus_epi32(row1, row1);
+				row1 = _mm_packus_epi16(row1, row1);
+				_mm_store_si128((__m128i *)Ybuf, tempI);
+				_mm_store_si128((__m128i *)(Ybuf + 4), row1);
+
+				U0_s = _mm_add_ps(U0_s, const128);
+				U1_s = _mm_add_ps(U1_s, const128);
+				tempI = _mm_cvttps_epi32(U0_s);
+				tempI = _mm_packus_epi32(tempI, tempI);
+				row1 = _mm_cvttps_epi32(U1_s);
+				row1 = _mm_packus_epi32(row1, row1);
+				tempI = _mm_avg_epu16(tempI, row1);
+				tempI = _mm_hadd_epi16(tempI, tempI);
+				tempI = _mm_cvtepi16_epi32(tempI);
+				row0 = _mm_set1_epi16(1);
+				tempI = _mm_add_epi16(tempI, row0);
+				tempI = _mm_srli_epi16(tempI, 1);
+				tempI = _mm_packus_epi32(tempI, tempI);
+				tempI = _mm_packus_epi16(tempI, tempI);
+				_mm_store_si128((__m128i *)Ubuf, tempI);
+
+				V0_s = _mm_add_ps(V0_s, const128);
+				V1_s = _mm_add_ps(V1_s, const128);
+				tempI = _mm_cvttps_epi32(V0_s);
+				tempI = _mm_packus_epi32(tempI, tempI);
+				row1 = _mm_cvttps_epi32(V1_s);
+				row1 = _mm_packus_epi32(row1, row1);
+				tempI = _mm_avg_epu16(tempI, row1);
+				tempI = _mm_hadd_epi16(tempI, tempI);
+				tempI = _mm_cvtepi16_epi32(tempI);
+				tempI = _mm_add_epi16(tempI, row0);
+				tempI = _mm_srli_epi16(tempI, 1);
+				tempI = _mm_packus_epi32(tempI, tempI);
+				tempI = _mm_packus_epi16(tempI, tempI);
+				_mm_store_si128((__m128i *)Vbuf, tempI);
+
+				*(unsigned int *)(pLocalDstY) = Ybuf[0];
+				*(unsigned int *)(pLocalDstY + dstYImageStrideInBytes) = Ybuf[4];
+				*(unsigned short *)(pLocalDstU) = Ubuf[0];
+				*(unsigned short *)(pLocalDstV) = Vbuf[0];
+
+				pLocalSrc  += 12;
+				pLocalDstY += 4;
+				pLocalDstU += 2;
+				pLocalDstV += 2;
+			}
+		}
+
+		for (int width = 0; width < avxPostfixWidth; width += 2)
+		{
+			float R = (float)*(pLocalSrc);
+			float G = (float)*(pLocalSrc + 1);
+			float B = (float)*(pLocalSrc + 2);
+			*pLocalDstY = (vx_uint8)((R * 0.2126f) + (G * 0.7152f) + (B * 0.0722));
+			float U = (R * -0.1146f) + (G * -0.3854f) + (B * 0.5f) + 128.0f;
+			float V = (R * 0.5f) + (G * -0.4542f) + (B * -0.0458f) + 128.0f;
+			R = (float)*(pLocalSrc + 3);
+			G = (float)*(pLocalSrc + 4);
+			B = (float)*(pLocalSrc + 5);
+			*(pLocalDstY + 1) = (vx_uint8)((R * 0.2126f) + (G * 0.7152f) + (B * 0.0722));
+			U += ((R * -0.1146f) + (G * -0.3854f) + (B * 0.5f) + 128.0f);
+			V += ((R * 0.5f) + (G * -0.4542f) + (B * -0.0458f) + 128.0f);
+			R = (float)*(pLocalSrc + srcImageStrideInBytes);
+			G = (float)*(pLocalSrc + srcImageStrideInBytes + 1);
+			B = (float)*(pLocalSrc + srcImageStrideInBytes + 2);
+			*(pLocalDstY + dstYImageStrideInBytes) = (vx_uint8)((R * 0.2126f) + (G * 0.7152f) + (B * 0.0722));
+			U += ((R * -0.1146f) + (G * -0.3854f) + (B * 0.5f) + 128.0f);
+			V += ((R * 0.5f) + (G * -0.4542f) + (B * -0.0458f) + 128.0f);
+			R = (float)*(pLocalSrc + srcImageStrideInBytes + 3);
+			G = (float)*(pLocalSrc + srcImageStrideInBytes + 4);
+			B = (float)*(pLocalSrc + srcImageStrideInBytes + 5);
+			*(pLocalDstY + dstYImageStrideInBytes + 1) = (vx_uint8)((R * 0.2126f) + (G * 0.7152f) + (B * 0.0722));
+			U += ((R * -0.1146f) + (G * -0.3854f) + (B * 0.5f) + 128.0f);
+			V += ((R * 0.5f) + (G * -0.4542f) + (B * -0.0458f) + 128.0f);
+			U /= 4.0f; V /= 4.0f;
+			*pLocalDstU++ = (vx_uint8)U;
+			*pLocalDstV++ = (vx_uint8)V;
+			pLocalSrc += 6;
+			pLocalDstY += 2;
+		}
+
+		pSrcImage  += (srcImageStrideInBytes + srcImageStrideInBytes);
+		pDstYImage += (dstYImageStrideInBytes + dstYImageStrideInBytes);
+		pDstUImage += dstUImageStrideInBytes;
+		pDstVImage += dstVImageStrideInBytes;
+	}
+	return AGO_SUCCESS;
+#else
 	int alignedWidth = dstWidth & ~3;
 	int postfixWidth = (int)dstWidth - alignedWidth;
 
@@ -2702,6 +3007,7 @@ int HafCpu_ColorConvert_IYUV_RGB
 		pDstVImage += dstVImageStrideInBytes;
 	}
 	return AGO_SUCCESS;
+#endif
 }
 
 int HafCpu_ColorConvert_NV12_RGB

--- a/amd_openvx/openvx/ago/ago_haf_cpu_color_convert.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_color_convert.cpp
@@ -2520,36 +2520,38 @@ int HafCpu_ColorConvert_IYUV_RGB
 
 	// Shuffle masks for one __m256i that holds two 128-bit lanes of RGB
 	// bytes. Lane 0 covers bytes 0..15 of the row (pixels 0..4 plus some
-	// extra) and lane 1 covers bytes 12..27 (pixels 4..7 plus some
-	// extra). Each mask extracts one channel per pixel into the low
-	// byte of every 32-bit lane.
+	// extra) and lane 1 covers bytes 8..23 (pixels 2..7). For lane 1 we
+	// extract only pixels 4..7, whose channel byte offsets within the
+	// +8 load are R={4,7,10,13}, G={5,8,11,14}, B={6,9,12,15}. Each mask
+	// extracts one channel per pixel into the low byte of every 32-bit
+	// lane.
 	const __m256i mask_R256 = _mm256_setr_epi8(
 		 0, (char)0x80, (char)0x80, (char)0x80,
 		 3, (char)0x80, (char)0x80, (char)0x80,
 		 6, (char)0x80, (char)0x80, (char)0x80,
 		 9, (char)0x80, (char)0x80, (char)0x80,
-		 0, (char)0x80, (char)0x80, (char)0x80,
-		 3, (char)0x80, (char)0x80, (char)0x80,
-		 6, (char)0x80, (char)0x80, (char)0x80,
-		 9, (char)0x80, (char)0x80, (char)0x80);
+		 4, (char)0x80, (char)0x80, (char)0x80,
+		 7, (char)0x80, (char)0x80, (char)0x80,
+		10, (char)0x80, (char)0x80, (char)0x80,
+		13, (char)0x80, (char)0x80, (char)0x80);
 	const __m256i mask_G256 = _mm256_setr_epi8(
 		 1, (char)0x80, (char)0x80, (char)0x80,
 		 4, (char)0x80, (char)0x80, (char)0x80,
 		 7, (char)0x80, (char)0x80, (char)0x80,
 		10, (char)0x80, (char)0x80, (char)0x80,
-		 1, (char)0x80, (char)0x80, (char)0x80,
-		 4, (char)0x80, (char)0x80, (char)0x80,
-		 7, (char)0x80, (char)0x80, (char)0x80,
-		10, (char)0x80, (char)0x80, (char)0x80);
+		 5, (char)0x80, (char)0x80, (char)0x80,
+		 8, (char)0x80, (char)0x80, (char)0x80,
+		11, (char)0x80, (char)0x80, (char)0x80,
+		14, (char)0x80, (char)0x80, (char)0x80);
 	const __m256i mask_B256 = _mm256_setr_epi8(
 		 2, (char)0x80, (char)0x80, (char)0x80,
 		 5, (char)0x80, (char)0x80, (char)0x80,
 		 8, (char)0x80, (char)0x80, (char)0x80,
 		11, (char)0x80, (char)0x80, (char)0x80,
-		 2, (char)0x80, (char)0x80, (char)0x80,
-		 5, (char)0x80, (char)0x80, (char)0x80,
-		 8, (char)0x80, (char)0x80, (char)0x80,
-		11, (char)0x80, (char)0x80, (char)0x80);
+		 6, (char)0x80, (char)0x80, (char)0x80,
+		 9, (char)0x80, (char)0x80, (char)0x80,
+		12, (char)0x80, (char)0x80, (char)0x80,
+		15, (char)0x80, (char)0x80, (char)0x80);
 
 	const __m256 cYR = _mm256_set1_ps( 0.2126f);
 	const __m256 cYG = _mm256_set1_ps( 0.7152f);
@@ -2573,24 +2575,20 @@ int HafCpu_ColorConvert_IYUV_RGB
 		for (int width = 0; width < (avxAlignedWidth >> 3); width++)
 		{
 			// Build the 32-byte working set per row from two 16-byte
-			// loads. The high-half load at offset +12 brings pixels
-			// 4..7 into lane 1 of the __m256i so a single in-lane
-			// shuffle covers all 8 pixels.
-			//
-			// Memory safety: per row we read bytes 0..27 (the +12 load
-			// reaches byte 27). The OpenVX image pitch always rounds
-			// up to a multiple of 16 bytes, so the only risk would be
-			// the very last row of the very last AVX iter on a width
-			// that's an exact multiple of 8. dstWidth is u32 and the
-			// loop bound is the floored multiple, so the +12 load
-			// stays inside the row's allocated pitch (>= 3*dstWidth
-			// rounded up to 16) for any dstWidth >= 8.
+			// loads. The high-half load is taken from offset +8
+			// (bytes 8..23) so all source bytes referenced this
+			// iteration stay inside the 24-byte RGB span for 8
+			// pixels. This avoids any read past the end of the row
+			// even when srcImageStrideInBytes is exactly 3*dstWidth
+			// (no trailing pitch padding). Lane 1's shuffle masks
+			// are shifted accordingly so pixels 4..7 are extracted
+			// from offsets {4,7,10,13} / {5,8,11,14} / {6,9,12,15}.
 			__m128i src0_lo = _mm_loadu_si128((__m128i *)(pLocalSrc));
-			__m128i src0_hi = _mm_loadu_si128((__m128i *)(pLocalSrc + 12));
+			__m128i src0_hi = _mm_loadu_si128((__m128i *)(pLocalSrc + 8));
 			__m256i src0    = _mm256_inserti128_si256(_mm256_castsi128_si256(src0_lo), src0_hi, 1);
 
 			__m128i src1_lo = _mm_loadu_si128((__m128i *)(pLocalSrc + srcImageStrideInBytes));
-			__m128i src1_hi = _mm_loadu_si128((__m128i *)(pLocalSrc + srcImageStrideInBytes + 12));
+			__m128i src1_hi = _mm_loadu_si128((__m128i *)(pLocalSrc + srcImageStrideInBytes + 8));
 			__m256i src1    = _mm256_inserti128_si256(_mm256_castsi128_si256(src1_lo), src1_hi, 1);
 
 			__m256 R0 = _mm256_cvtepi32_ps(_mm256_shuffle_epi8(src0, mask_R256));

--- a/amd_openvx/openvx/ago/ago_haf_cpu_filter.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_filter.cpp
@@ -3336,10 +3336,14 @@ int HafCpu_Convolve_U8_U8_3xN
 				result0 = _mm_add_epi32(result0, temp0);
 			}
 
-			result0 = _mm_srli_epi32(result0, shift);
-			result1 = _mm_srli_epi32(result1, shift);
-			result2 = _mm_srli_epi32(result2, shift);
-			result3 = _mm_srli_epi32(result3, shift);
+			// Arithmetic right shift (sign-preserving) so negative
+			// intermediates saturate to 0 in the subsequent unsigned
+			// pack to U8. This matches the scalar prefix/postfix
+			// clamp(0,255) behavior and the AVX2 path above.
+			result0 = _mm_srai_epi32(result0, shift);
+			result1 = _mm_srai_epi32(result1, shift);
+			result2 = _mm_srai_epi32(result2, shift);
+			result3 = _mm_srai_epi32(result3, shift);
 
 			row = _mm_packs_epi32(result2, result3);
 			temp0 = _mm_packs_epi32(result0, result1);

--- a/amd_openvx/openvx/ago/ago_haf_cpu_filter.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_filter.cpp
@@ -52,13 +52,7 @@ static inline __m128i HafCpu_FastAtan2_PhaseByte_8(__m128i gx16, __m128i gy16)
 	__m256 useX = _mm256_cmp_ps(ay, ax, _CMP_LE_OQ);
 	__m256 mn = _mm256_min_ps(ax, ay);
 	__m256 mx = _mm256_max_ps(ax, ay);
-	// Use rcp_ps + one Newton-Raphson step (~24-bit precision) instead of
-	// _mm256_div_ps. Final output is u8 with +/-1 tolerance so the residual
-	// precision loss is well within spec.
-	__m256 d = _mm256_add_ps(mx, eps);
-	__m256 r = _mm256_rcp_ps(d);
-	r = _mm256_mul_ps(r, _mm256_sub_ps(_mm256_set1_ps(2.0f), _mm256_mul_ps(d, r)));
-	__m256 c = _mm256_mul_ps(mn, r);
+	__m256 c = _mm256_div_ps(mn, _mm256_add_ps(mx, eps));
 	__m256 c2 = _mm256_mul_ps(c, c);
 	__m256 poly = _mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(p7, c2), p5), c2), p3), c2), p1), c);
 	__m256 angle = _mm256_blendv_ps(_mm256_sub_ps(ninety, poly), poly, useX);

--- a/amd_openvx/openvx/ago/ago_haf_cpu_filter.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_filter.cpp
@@ -52,7 +52,13 @@ static inline __m128i HafCpu_FastAtan2_PhaseByte_8(__m128i gx16, __m128i gy16)
 	__m256 useX = _mm256_cmp_ps(ay, ax, _CMP_LE_OQ);
 	__m256 mn = _mm256_min_ps(ax, ay);
 	__m256 mx = _mm256_max_ps(ax, ay);
-	__m256 c = _mm256_div_ps(mn, _mm256_add_ps(mx, eps));
+	// Use rcp_ps + one Newton-Raphson step (~24-bit precision) instead of
+	// _mm256_div_ps. Final output is u8 with +/-1 tolerance so the residual
+	// precision loss is well within spec.
+	__m256 d = _mm256_add_ps(mx, eps);
+	__m256 r = _mm256_rcp_ps(d);
+	r = _mm256_mul_ps(r, _mm256_sub_ps(_mm256_set1_ps(2.0f), _mm256_mul_ps(d, r)));
+	__m256 c = _mm256_mul_ps(mn, r);
 	__m256 c2 = _mm256_mul_ps(c, c);
 	__m256 poly = _mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(p7, c2), p5), c2), p3), c2), p1), c);
 	__m256 angle = _mm256_blendv_ps(_mm256_sub_ps(ninety, poly), poly, useX);
@@ -3182,7 +3188,73 @@ int HafCpu_Convolve_U8_U8_3xN
 		}
 
 		pLocalDst_xmm = (__m128i *) pLocalDst;
-		int width = (int)(alignedWidth >> 4);							// Each loop processess 16 pixels
+
+		int remainingWidth = alignedWidth;
+#if USE_AVX
+		// AVX2 path: process 32 dst pixels per iter using mullo/mulhi_epi16
+		// (1-cycle throughput on Zen) instead of the SSE path's mullo_epi32
+		// (3-cycle throughput). For each conv coefficient we widen 32 source
+		// bytes to two __m256i s16 vectors and accumulate full-width s32
+		// partial products into four lane accumulators.
+		int avxWidth = remainingWidth & ~31;							// multiple of 32 dst pixels
+		int width32 = avxWidth >> 5;
+		remainingWidth -= avxWidth;
+		while (width32)
+		{
+			pLocalConvMat = convMatrix + numConvCoeffs - 1;
+			__m256i acc0 = _mm256_setzero_si256();
+			__m256i acc1 = _mm256_setzero_si256();
+			__m256i acc2 = _mm256_setzero_si256();
+			__m256i acc3 = _mm256_setzero_si256();
+
+			for (int y = -rowLimit; y <= rowLimit; y++)
+			{
+				int offset = y * srcStride;
+				// Three horizontal taps share two underlying 32-byte loads:
+				// load[0] covers src[-1..30] (shifted-left + at-loc), load[1] covers src[31..32]
+				// We just do three loadu — they're cheap on cached data.
+				for (int xoff = -1; xoff <= 1; xoff++)
+				{
+					__m256i src32 = _mm256_loadu_si256((__m256i *)(pLocalSrc + offset + xoff));
+					__m256i src_lo16 = _mm256_cvtepu8_epi16(_mm256_castsi256_si128(src32));
+					__m256i src_hi16 = _mm256_cvtepu8_epi16(_mm256_extracti128_si256(src32, 1));
+					__m256i cv = _mm256_set1_epi16((short)(*pLocalConvMat--));
+					__m256i lo_l = _mm256_mullo_epi16(src_lo16, cv);
+					__m256i lo_h = _mm256_mulhi_epi16(src_lo16, cv);
+					__m256i hi_l = _mm256_mullo_epi16(src_hi16, cv);
+					__m256i hi_h = _mm256_mulhi_epi16(src_hi16, cv);
+					// In-lane unpack: produces correct sequential s32 within each 128-bit lane.
+					acc0 = _mm256_add_epi32(acc0, _mm256_unpacklo_epi16(lo_l, lo_h));
+					acc1 = _mm256_add_epi32(acc1, _mm256_unpackhi_epi16(lo_l, lo_h));
+					acc2 = _mm256_add_epi32(acc2, _mm256_unpacklo_epi16(hi_l, hi_h));
+					acc3 = _mm256_add_epi32(acc3, _mm256_unpackhi_epi16(hi_l, hi_h));
+				}
+			}
+
+			// Arithmetic right shift so negative intermediates clamp correctly
+			// in the subsequent unsigned-saturating pack to U8.
+			acc0 = _mm256_srai_epi32(acc0, shift);
+			acc1 = _mm256_srai_epi32(acc1, shift);
+			acc2 = _mm256_srai_epi32(acc2, shift);
+			acc3 = _mm256_srai_epi32(acc3, shift);
+
+			// In-lane packs_epi32 collapses to sequential s16 within each 128-bit lane.
+			__m256i s16_lo = _mm256_packs_epi32(acc0, acc1);
+			__m256i s16_hi = _mm256_packs_epi32(acc2, acc3);
+			// In-lane packus_epi16 of s16_lo + s16_hi produces:
+			//   lane0 bytes: s16_lo lane0 (bytes 0..7) + s16_hi lane0 (bytes 8..15)
+			//   lane1 bytes: s16_lo lane1 (bytes 0..7) + s16_hi lane1 (bytes 8..15)
+			// We need bytes 0..15 from s16_lo, bytes 16..31 from s16_hi, so reshuffle 64-bit lanes.
+			__m256i packed = _mm256_packus_epi16(s16_lo, s16_hi);
+			packed = _mm256_permute4x64_epi64(packed, 0xD8); // (0, 2, 1, 3)
+			_mm256_storeu_si256((__m256i *)pLocalDst_xmm, packed);
+			pLocalDst_xmm = (__m128i *)((char *)pLocalDst_xmm + 32);
+			pLocalSrc += 32;
+			width32--;
+		}
+#endif
+
+		int width = remainingWidth >> 4;								// Each loop processess 16 pixels
 		while (width)
 		{
 			pLocalConvMat = convMatrix + numConvCoeffs - 1;


### PR DESCRIPTION
## Summary

Follow-up to #1663 targeting the kernels still below 1x OpenCV parity in the openvx-mark FHD benchmark on the `conformance.yml` CI matrix:

| Kernel                       | Baseline | Change                                                                                          |
| ---------------------------- | -------: | ----------------------------------------------------------------------------------------------- |
| `MeanStdDev`                 |    0.40x | Four independent AVX2 accumulator chains over 128-byte blocks; defer i32->i64 widening of squared-sums every 8192 32-byte iters (breaks `sumSquared` dep chain). |
| `MinMax`                     |    0.43x | Unroll to 128-byte chunks with 4 independent min/max accumulator chains; in-lane reduction. Early-exit once full U8 extrema range is observed. |
| `MinMaxLoc` (Count_* trio)   |    0.43x | AVX2 32-byte loop + `HafCpu_PopCount32` on each movemask; eliminates per-bit iteration loop.    |
| `CustomConvolution`          |    0.70x | New AVX2 3xN path: 32 dst pixels/iter using `mullo/mulhi_epi16` (1c) vs SSE `mullo_epi32` (3c). |
| `ColorConvert_RGB2IYUV`      |    0.58x | New AVX2 path on `HafCpu_ColorConvert_IYUV_RGB`: 8 RGB pixels/row × 2 rows per iter; bit-identical to SSE for every aligned 8-pixel column. |

Also picked up a **pre-existing copy-paste bug** in `HafCpu_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Max`: the prefix/postfix scalar tails were comparing against `globalMin` instead of `globalMax`. This only fires on non-16-aligned widths, which is why the CTS (mostly aligned images) masked it.

> **Note on `Phase`:** an initial `_mm256_div_ps` -> `rcp_ps + 1 Newton-Raphson` replacement at both call sites (`HafCpu_Phase_U8_S16S16`, `HafCpu_FastAtan2_PhaseByte_8`) was reverted later in this PR after the CI benchmark showed a regression on the runner microarchitecture (the loop turned out to be latency-bound rather than div-throughput-bound). Both kernels are restored to the pre-PR `_mm256_div_ps(mn, mx + eps)` form.

## Files touched

- `amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp` — MeanStdDev, MinMax_U8, MinMaxLoc x3 paths.
- `amd_openvx/openvx/ago/ago_haf_cpu_filter.cpp` — Convolve_U8_U8_3xN AVX2 path.
- `amd_openvx/openvx/ago/ago_haf_cpu_color_convert.cpp` — ColorConvert_IYUV_RGB AVX2 path (RGB -> IYUV).

## Conformance

Full OpenVX-cts 1.3 run against the rebuilt `libopenvx` (HOST backend, macOS dev box):

```
#REPORT: 20260521180219 ALL 15277 8190 5820 5820 5817 3 (version 1.3)
```

- **5820 tests run, 5817 pass, 3 fail.**
- The 3 failures are the same pre-existing macOS-only `SmokeTestBase.{vxReleaseReferenceBase, vxLoadKernels, vxUnloadKernels}` dynamic-loading failures present on the parent commit (#1663) before any of these edits. They do not exercise kernel correctness and are not present on Linux CI.

Targeted kernel filter
(`*MinMaxLoc*:*MinMax*:*MeanStdDev*:*ColorConvert*:*Phase*:*Magnitude*:*Convolve*:*CustomConvolution*:*ChannelExtract*:*ChannelCombine*`):

- All targeted CTS subsets pass against the rebuilt library on every commit on this branch.

## openvx-mark FHD speed-ups (CI runner, vs OpenCV reference)

Confirmed wins on the `Release OpenVX vs OpenCV benchmark` CI step:

- `MeanStdDev`              0.40x -> 0.82x (+106%)
- `CustomConvolution`       0.70x -> 1.16x (+66%)
- `ColorConvert_RGB2IYUV`   0.58x -> 1.19x (+105%)

`MinMaxLoc` only moves 0.43x -> 0.46x because `cv::minMaxLoc` asks for locations, so the OpenVX path actually exercises `HafCpu_MinMaxLoc_..._Loc_MinMax_Count_MinMax` (already AVX2 + popcount-optimized) rather than the `Loc_None_Count_*` variants touched here. Closing that remaining gap requires a graph-level fused kernel and is intentionally deferred to a separate PR.

## Test plan

- [x] Local CMake build (Release, HOST backend) clean: `cmake --build . --target openvx`.
- [x] OpenVX-cts 1.3 full suite — 5817 / 5820 pass (3 pre-existing macOS smoke-load failures unrelated to kernels).
- [x] Targeted CTS subset for every touched kernel.
- [x] Linux `conformance.yml` matrix on this PR confirms baseline + vision-* parity stays green and `Release OpenVX vs OpenCV benchmark` shows the targeted kernels moving toward 1x.

## Not in this PR (intentionally deferred)

- `MinMaxLoc` end-to-end (graph-level): currently the graph decomposes `MinMaxLoc` into a separate `MinMax` pass + a `MinMaxLoc` pass, so the data is scanned twice end-to-end. Closing the remaining gap requires a fused kernel at the graph layer.
- `LaplacianPyramid` (0.20x) — already heavily fused after #1663; remaining gap looks structural vs OpenCV's pyramid pipeline and warrants a deeper look.


Made with [Cursor](https://cursor.com)
