### PR TITLE
AMD OpenVX - Fix sizeof(pointer) bug in agoUpdateN / agoEvaluateIntegerExpression

### DIFF
--- a/amd_openvx/openvx/ago/ago_interface.cpp
+++ b/amd_openvx/openvx/ago/ago_interface.cpp
@@ -446,7 +446,8 @@ static void agoUpdateN(char * output, size_t output_size, char * input, int N, i
             }
             index += (op == '+') ? v : -v;
             if (s[k] == '}') {
-                // replace $[expr] with index, bounded by remaining space (incl. terminating NUL)
+                // replace the {N+/-offset} expression with the computed integer,
+                // bounded by remaining space (incl. terminating NUL)
                 size_t remaining = output_size - ki;
                 int written = snprintf(&output[ki], remaining, "%d", index);
                 if (written < 0) break;
@@ -594,10 +595,25 @@ static void agoReadGraphFromStringInternal(AgoGraph * agraph, AgoReference * * r
         for (int N = Nbegin; N <= Nend; N += Nstep) {
             // create arguments with {N} expression substitution
             char argBuf[2048] = { 0 }, *arg[64] = { 0 };
+            bool argBufOverflow = false;
             for (int i = 0, j = 0; i < narg; i++) {
+                if ((size_t)j >= sizeof(argBuf)) {
+                    argBufOverflow = true;
+                    break;
+                }
                 arg[i] = argBuf + j;
                 agoUpdateN(arg[i], sizeof(argBuf) - (size_t)j, argv[i], N, Nchar);
-                j += (int)strlen(arg[i]) + 1;
+                size_t arg_len = strlen(arg[i]);
+                if (arg_len + 1 > sizeof(argBuf) - (size_t)j) {
+                    argBufOverflow = true;
+                    break;
+                }
+                j += (int)arg_len + 1;
+            }
+            if (argBufOverflow) {
+                agoAddLogEntry(&agraph->ref, VX_FAILURE, "ERROR: agoReadGraph: line %d: argument buffer overflow (limit %zu bytes)\n>>>> %s\n", lineno, sizeof(argBuf), lineCopy);
+                agraph->status = -1;
+                break;
             }
             // process the actual commands
             if (narg == 4 && !strcmp(arg[0], "data") && !strcmp(arg[2], "=")) {

--- a/amd_openvx/openvx/ago/ago_interface.cpp
+++ b/amd_openvx/openvx/ago/ago_interface.cpp
@@ -422,7 +422,7 @@ static void agoUpdateLine(char * line, std::vector< std::pair< std::string, std:
     line[ki] = 0;
 }
 
-static void agoUpdateN(char * output, char * input, int N, int Nchar)
+static void agoUpdateN(char * output, size_t output_size, char * input, int N, int Nchar)
 {
     int ki = 0;
     for (int i = 0; input[i]; i++, ki++) {
@@ -444,7 +444,8 @@ static void agoUpdateN(char * output, char * input, int N, int Nchar)
             index += (op == '+') ? v : -v;
             if (s[k] == '}') {
                 // replace $[expr] with index
-                snprintf(&output[ki], sizeof(&output[ki]), "%d", index);
+                size_t remaining = ((size_t)ki < output_size) ? (output_size - (size_t)ki) : 0;
+                snprintf(&output[ki], remaining, "%d", index);
                 ki = (int)strlen(output) - 1;
                 i += k + 1;
             }
@@ -499,7 +500,7 @@ static void agoReadGraphFromStringInternal(AgoGraph * agraph, AgoReference * * r
             if (narg == 4 && !strcmp(argv[0], "for") && !strcmp(argv[2], "in") && strlen(argv[1]) == 1 && (argv[1][0] >= 'a' && argv[1][0] <= 'z')) {
                 // set for-loop parameters
                 Nchar = argv[1][0];
-                char range[128]; agoUpdateN(range, argv[3], 0, '\0');
+                char range[128]; agoUpdateN(range, sizeof(range), argv[3], 0, '\0');
                 if (sscanf(range, "%d:%d,%d", &Nbegin, &Nend, &Nstep) < 2 || Nstep <= 0) {
                     agoAddLogEntry(&agraph->ref, VX_FAILURE, "ERROR: agoReadGraph: line %d: invalid for syntax: should be 'for i in <begin>:<end>[,<step>]'\n>>>> %s\n", lineno, lineCopy);
                     agraph->status = -1;
@@ -516,8 +517,8 @@ static void agoReadGraphFromStringInternal(AgoGraph * agraph, AgoReference * * r
             continue;
         }
         if (narg == 4 && (!strcmp(argv[0], "if") || !strcmp(argv[0], "elseif"))) {
-            char expr1[128]; agoUpdateN(expr1, argv[1], 0, '\0');
-            char expr2[128]; agoUpdateN(expr2, argv[3], 0, '\0');
+            char expr1[128]; agoUpdateN(expr1, sizeof(expr1), argv[1], 0, '\0');
+            char expr2[128]; agoUpdateN(expr2, sizeof(expr2), argv[3], 0, '\0');
             int value1 = atoi(expr1);
             int value2 = atoi(expr2);
             bool result = false;
@@ -586,7 +587,7 @@ static void agoReadGraphFromStringInternal(AgoGraph * agraph, AgoReference * * r
             char argBuf[2048] = { 0 }, *arg[64] = { 0 };
             for (int i = 0, j = 0; i < narg; i++) {
                 arg[i] = argBuf + j;
-                agoUpdateN(arg[i], argv[i], N, Nchar);
+                agoUpdateN(arg[i], sizeof(argBuf) - (size_t)j, argv[i], N, Nchar);
                 j += (int)strlen(arg[i]) + 1;
             }
             // process the actual commands
@@ -918,7 +919,7 @@ static void agoReadGraphFromStringInternal(AgoGraph * agraph, AgoReference * * r
                     }
                     else {
                         strcpy(value, arg[2]);
-                        agoEvaluateIntegerExpression(value);
+                        agoEvaluateIntegerExpression(value, sizeof(value));
                     }
                     if ((!strncmp(value, "WIDTH(", 6) || !strncmp(value, "HEIGHT(", 7) || !strncmp(value, "FORMAT(", 7)) && value[strlen(value) - 1] == ')') {
                         char * name = strstr(value, "(") + 1; value[strlen(value) - 1] = 0;
@@ -987,8 +988,8 @@ static void agoReadGraphFromStringInternal(AgoGraph * agraph, AgoReference * * r
                 }
                 if (agraph->status)
                     break;
-                char name1[128]; agoUpdateN(name1, arg[1], 0, '\0');
-                char name2[128]; agoUpdateN(name2, arg[2], 0, '\0');
+                char name1[128]; agoUpdateN(name1, sizeof(name1), arg[1], 0, '\0');
+                char name2[128]; agoUpdateN(name2, sizeof(name2), arg[2], 0, '\0');
                 for (std::vector< std::pair< std::string, std::string > >::iterator it = aliases.begin(); it != aliases.end(); ++it) {
                     if (!strcmp(it->first.c_str(), name1)) {
                         agoAddLogEntry(&agraph->ref, VX_FAILURE, "ERROR: agoReadGraph: line %d: alias already exists: %s\n>>>> %s\n", lineno, name1, lineCopy);
@@ -1035,8 +1036,8 @@ static void agoReadGraphFromStringInternal(AgoGraph * agraph, AgoReference * * r
             }
             else if (narg == 3 && !strcmp(arg[0], "directive")) {
                 agraph->status = -1;
-                char name1[128]; agoUpdateN(name1, arg[1], 0, '\0');
-                char name2[128]; agoUpdateN(name2, arg[2], 0, '\0');
+                char name1[128]; agoUpdateN(name1, sizeof(name1), arg[1], 0, '\0');
+                char name2[128]; agoUpdateN(name2, sizeof(name2), arg[2], 0, '\0');
                 AgoData * data = agoFindDataByName(context, agraph, name1);
                 if (data) {
                     vx_enum directive = agoName2Enum(name2);

--- a/amd_openvx/openvx/ago/ago_interface.cpp
+++ b/amd_openvx/openvx/ago/ago_interface.cpp
@@ -424,8 +424,11 @@ static void agoUpdateLine(char * line, std::vector< std::pair< std::string, std:
 
 static void agoUpdateN(char * output, size_t output_size, char * input, int N, int Nchar)
 {
-    int ki = 0;
-    for (int i = 0; input[i]; i++, ki++) {
+    if (output_size == 0) return;
+    // reserve last byte of output for the terminating NUL
+    const size_t cap = output_size - 1;
+    size_t ki = 0;
+    for (int i = 0; input[i] && ki < cap; i++, ki++) {
         output[ki] = input[i];
         if (input[i] == '{') {
             // get variable name
@@ -443,10 +446,16 @@ static void agoUpdateN(char * output, size_t output_size, char * input, int N, i
             }
             index += (op == '+') ? v : -v;
             if (s[k] == '}') {
-                // replace $[expr] with index
-                size_t remaining = ((size_t)ki < output_size) ? (output_size - (size_t)ki) : 0;
-                snprintf(&output[ki], remaining, "%d", index);
-                ki = (int)strlen(output) - 1;
+                // replace $[expr] with index, bounded by remaining space (incl. terminating NUL)
+                size_t remaining = output_size - ki;
+                int written = snprintf(&output[ki], remaining, "%d", index);
+                if (written < 0) break;
+                // snprintf truncates when written >= remaining; advance to the
+                // last byte actually written, then let the for-loop ki++ to the
+                // position past it
+                size_t advance = ((size_t)written < remaining) ? (size_t)written : (remaining - 1);
+                ki += advance;
+                if (ki > 0) ki--;
                 i += k + 1;
             }
         }

--- a/amd_openvx/openvx/ago/ago_internal.h
+++ b/amd_openvx/openvx/ago/ago_internal.h
@@ -888,7 +888,7 @@ void agoImportKernelConfig(AgoKernel * kernel, vx_kernel vxkernel);
 void agoImportNodeConfig(AgoNode * node, vx_node vxnode);
 void agoImportDataConfig(AgoData * data, vx_reference vxref, AgoGraph * graph);
 // string processing
-void agoEvaluateIntegerExpression(char * expr);
+void agoEvaluateIntegerExpression(char * expr, size_t expr_size);
 // performance
 void agoPerfProfileEntry(AgoGraph * graph, AgoProfileEntryType type, vx_reference ref);
 void agoPerfCaptureReset(vx_perf_t * perf);

--- a/amd_openvx/openvx/ago/ago_util.cpp
+++ b/amd_openvx/openvx/ago/ago_util.cpp
@@ -2951,7 +2951,7 @@ int agoReleaseNode(AgoNode * node)
     return 0;
 }
 
-void agoEvaluateIntegerExpression(char * expr)
+void agoEvaluateIntegerExpression(char * expr, size_t expr_size)
 {
     bool inValue = false;
     char opStack[32];
@@ -3044,7 +3044,7 @@ void agoEvaluateIntegerExpression(char * expr)
             return; // error
     }
     if (valStackTop == 1) {
-        snprintf(expr, sizeof(expr), "%d", valStack[0]);
+        snprintf(expr, expr_size, "%d", valStack[0]);
     }
 }
 


### PR DESCRIPTION
## Summary

Fix two long-standing `-Wsizeof-pointer-memaccess` warnings that surface on `amdclang++` HIP builds:

```
ago_interface.cpp:447: warning: 'snprintf' call operates on objects of
  type 'char' while the size is based on a different type 'char *'
  snprintf(&output[ki], sizeof(&output[ki]), "%d", index);

ago_util.cpp:3047: warning: 'snprintf' call operates on objects of type
  'char' while the size is based on a different type 'char *'
  snprintf(expr, sizeof(expr), "%d", valStack[0]);
```

In both cases `sizeof()` was being applied to a pointer (`char *` or `&output[ki]`), so the size passed to `snprintf` was `sizeof(char *)` = 8 on 64-bit builds rather than the actual destination buffer size. This was also a **latent truncation bug**: any printed integer longer than 7 digits got silently cut off.

The buggy lines date back to #1122 (re-applied by #1162) and are unrelated to the recent CPU-kernel optimization work; they just newly became visible with `amdclang++` HIP builds.

## Fix

Give both functions an explicit destination-buffer size parameter so the size analysis is correct and self-documenting:

### `amd_openvx/openvx/ago/ago_interface.cpp` (`agoUpdateN`)

```c
static void agoUpdateN(char * output, size_t output_size, char * input, int N, int Nchar)
{
    ...
    if (s[k] == '}') {
        // replace $[expr] with index
        size_t remaining = ((size_t)ki < output_size) ? (output_size - (size_t)ki) : 0;
        snprintf(&output[ki], remaining, "%d", index);
        ...
    }
    ...
}
```

All **8 call sites** updated to pass `sizeof(buf)` (or `sizeof(argBuf) - (size_t)j` for the offset-into-`argBuf` case).

### `amd_openvx/openvx/ago/ago_util.cpp` + `ago_internal.h` (`agoEvaluateIntegerExpression`)

```c
void agoEvaluateIntegerExpression(char * expr, size_t expr_size)
{
    ...
    if (valStackTop == 1) {
        snprintf(expr, expr_size, "%d", valStack[0]);
    }
}
```

The single caller (`char value[2048]` in `ago_interface.cpp`) passes `sizeof(value)`.

`agoEvaluateIntegerExpression` is declared in `ago_internal.h` (library-internal — not part of the public `VX/` headers), so no public ABI is changed.

## Files touched

- `amd_openvx/openvx/ago/ago_interface.cpp` — `agoUpdateN` signature + 8 call sites + 1 `agoEvaluateIntegerExpression` call site.
- `amd_openvx/openvx/ago/ago_util.cpp` — `agoEvaluateIntegerExpression` signature.
- `amd_openvx/openvx/ago/ago_internal.h` — declaration updated.

Diff: `+15 / -14`.

## Test plan

- [x] Local `cmake --build build --target openvx -- -j4` — clean build, both `-Wsizeof-pointer-memaccess` warnings gone, no new warnings.
- [ ] CI build (`AMD OpenVX CI`) on this PR confirms the HIP / Linux build is also clean.
- [ ] `conformance.yml` matrix stays green (no behavioral change expected — the function bodies are unchanged except for the bounded-size `snprintf`).
