### PR TITLE
OpenVX - Fix phase performance

### DIFF
--- a/amd_openvx/openvx/CMakeLists.txt
+++ b/amd_openvx/openvx/CMakeLists.txt
@@ -169,8 +169,9 @@ if(WIN32)
 else()
     # -msse4.2 -- Support MMX, SSE, SSE2, SSE3, SSSE3, SSE4.1 and SSE4.2 built-in functions and code generation.
     # -mavx2   -- Support AVX2 256-bit SIMD operations for arithmetic and filter kernels.
+    # -mfma    -- Support FMA3 fused multiply-add for polynomial-heavy kernels (e.g. phase/atan2).
     # -mbmi2   -- Support BMI2 bit manipulation instructions for U1 image format operations.
-    target_compile_options(openvx PRIVATE -msse4.2 -mavx2 -mbmi2)
+    target_compile_options(openvx PRIVATE -msse4.2 -mavx2 -mfma -mbmi2)
     target_compile_definitions(openvx PRIVATE USE_AVX=1)
     target_compile_definitions(openvx PRIVATE USE_BMI2=1)
     if(NOT APPLE)

--- a/amd_openvx/openvx/CMakeLists.txt
+++ b/amd_openvx/openvx/CMakeLists.txt
@@ -173,6 +173,7 @@ else()
     # -mbmi2   -- Support BMI2 bit manipulation instructions for U1 image format operations.
     target_compile_options(openvx PRIVATE -msse4.2 -mavx2 -mfma -mbmi2)
     target_compile_definitions(openvx PRIVATE USE_AVX=1)
+    target_compile_definitions(openvx PRIVATE USE_FMA=1)
     target_compile_definitions(openvx PRIVATE USE_BMI2=1)
     if(NOT APPLE)
         target_link_libraries(openvx dl m)

--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -10294,6 +10294,7 @@ int HafCpu_Phase_U8_S16S16
 	unsigned int y = 0;
 #if USE_AVX
 	const __m256 eps = _mm256_set1_ps((float)DBL_EPSILON);
+	const __m256 two = _mm256_set1_ps(2.0f);
 	const __m256 zero = _mm256_setzero_ps();
 	const __m256 ninety = _mm256_set1_ps(90.0f);
 	const __m256 oneEighty = _mm256_set1_ps(180.0f);
@@ -10333,8 +10334,14 @@ int HafCpu_Phase_U8_S16S16
 			__m256 mnHi = _mm256_min_ps(axHi, ayHi);
 			__m256 mxHi = _mm256_max_ps(axHi, ayHi);
 
-			__m256 cLo = _mm256_div_ps(mnLo, _mm256_add_ps(mxLo, eps));
-			__m256 cHi = _mm256_div_ps(mnHi, _mm256_add_ps(mxHi, eps));
+			__m256 denLo = _mm256_add_ps(mxLo, eps);
+			__m256 denHi = _mm256_add_ps(mxHi, eps);
+			__m256 rLo = _mm256_rcp_ps(denLo);
+			__m256 rHi = _mm256_rcp_ps(denHi);
+			rLo = _mm256_mul_ps(rLo, _mm256_fnmadd_ps(denLo, rLo, two));
+			rHi = _mm256_mul_ps(rHi, _mm256_fnmadd_ps(denHi, rHi, two));
+			__m256 cLo = _mm256_mul_ps(mnLo, rLo);
+			__m256 cHi = _mm256_mul_ps(mnHi, rHi);
 			__m256 c2Lo = _mm256_mul_ps(cLo, cLo);
 			__m256 c2Hi = _mm256_mul_ps(cHi, cHi);
 
@@ -10370,7 +10377,10 @@ int HafCpu_Phase_U8_S16S16
 			__m256 useX = _mm256_cmp_ps(ay, ax, _CMP_LE_OQ);
 			__m256 mn = _mm256_min_ps(ax, ay);
 			__m256 mx = _mm256_max_ps(ax, ay);
-			__m256 c = _mm256_div_ps(mn, _mm256_add_ps(mx, eps));
+			__m256 den = _mm256_add_ps(mx, eps);
+			__m256 r = _mm256_rcp_ps(den);
+			r = _mm256_mul_ps(r, _mm256_fnmadd_ps(den, r, two));
+			__m256 c = _mm256_mul_ps(mn, r);
 			__m256 c2 = _mm256_mul_ps(c, c);
 			__m256 poly = _mm256_mul_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(c2, p7, p5), c2, p3), c2, p1), c);
 			__m256 angle = _mm256_blendv_ps(_mm256_sub_ps(ninety, poly), poly, useX);

--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -10282,8 +10282,9 @@ vx_int16      Gy
 #if USE_AVX
 // Fused multiply-add (a*b + c) with a non-FMA fallback so the AVX phase path
 // still compiles when the binary is built without FMA3 (USE_FMA=0). When
-// USE_FMA=1 the build adds -mfma and the runtime CPU gate in ago_platform.cpp
-// requires the FMA bit, so emitting _mm256_fmadd_ps here is safe.
+// USE_FMA=1 the build enables FMA instruction generation and the runtime CPU
+// gate in ago_platform.cpp requires the FMA bit, so emitting _mm256_fmadd_ps
+// here is safe.
 static inline __m256 HafCpu_FmaddAvx(__m256 a, __m256 b, __m256 c)
 {
 #if USE_FMA

--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -10338,8 +10338,8 @@ int HafCpu_Phase_U8_S16S16
 			__m256 c2Lo = _mm256_mul_ps(cLo, cLo);
 			__m256 c2Hi = _mm256_mul_ps(cHi, cHi);
 
-			__m256 polyLo = _mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(p7, c2Lo), p5), c2Lo), p3), c2Lo), p1), cLo);
-			__m256 polyHi = _mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(p7, c2Hi), p5), c2Hi), p3), c2Hi), p1), cHi);
+			__m256 polyLo = _mm256_mul_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(c2Lo, p7, p5), c2Lo, p3), c2Lo, p1), cLo);
+			__m256 polyHi = _mm256_mul_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(c2Hi, p7, p5), c2Hi, p3), c2Hi, p1), cHi);
 
 			__m256 angleLo = _mm256_blendv_ps(_mm256_sub_ps(ninety, polyLo), polyLo, useXLo);
 			__m256 angleHi = _mm256_blendv_ps(_mm256_sub_ps(ninety, polyHi), polyHi, useXHi);
@@ -10353,8 +10353,8 @@ int HafCpu_Phase_U8_S16S16
 			angleLo = _mm256_blendv_ps(angleLo, _mm256_sub_ps(threeSixty, angleLo), gyNegLo);
 			angleHi = _mm256_blendv_ps(angleHi, _mm256_sub_ps(threeSixty, angleHi), gyNegHi);
 
-			__m256i pLo = _mm256_cvttps_epi32(_mm256_add_ps(_mm256_mul_ps(angleLo, scale), half));
-			__m256i pHi = _mm256_cvttps_epi32(_mm256_add_ps(_mm256_mul_ps(angleHi, scale), half));
+			__m256i pLo = _mm256_cvttps_epi32(_mm256_fmadd_ps(angleLo, scale, half));
+			__m256i pHi = _mm256_cvttps_epi32(_mm256_fmadd_ps(angleHi, scale, half));
 			__m256i packed = _mm256_packs_epi32(pLo, pHi);
 			packed = _mm256_permute4x64_epi64(packed, 0xd8);
 			__m128i lo16 = _mm256_castsi256_si128(packed);
@@ -10372,14 +10372,14 @@ int HafCpu_Phase_U8_S16S16
 			__m256 mx = _mm256_max_ps(ax, ay);
 			__m256 c = _mm256_div_ps(mn, _mm256_add_ps(mx, eps));
 			__m256 c2 = _mm256_mul_ps(c, c);
-			__m256 poly = _mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(_mm256_add_ps(_mm256_mul_ps(p7, c2), p5), c2), p3), c2), p1), c);
+			__m256 poly = _mm256_mul_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(c2, p7, p5), c2, p3), c2, p1), c);
 			__m256 angle = _mm256_blendv_ps(_mm256_sub_ps(ninety, poly), poly, useX);
 
 			__m256 gxNeg = _mm256_castsi256_ps(_mm256_cmpgt_epi32(zero32, gx32));
 			__m256 gyNeg = _mm256_castsi256_ps(_mm256_cmpgt_epi32(zero32, gy32));
 			angle = _mm256_blendv_ps(angle, _mm256_sub_ps(oneEighty, angle), gxNeg);
 			angle = _mm256_blendv_ps(angle, _mm256_sub_ps(threeSixty, angle), gyNeg);
-			__m256i phase32 = _mm256_cvttps_epi32(_mm256_add_ps(_mm256_mul_ps(angle, scale), half));
+			__m256i phase32 = _mm256_cvttps_epi32(_mm256_fmadd_ps(angle, scale, half));
 			__m128i phase16 = _mm_packs_epi32(_mm256_castsi256_si128(phase32), _mm256_extracti128_si256(phase32, 1));
 			__m128i phase8 = _mm_packus_epi16(phase16, phase16);
 			_mm_storel_epi64((__m128i *)(pdst + x), phase8);

--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -10279,6 +10279,21 @@ vx_int16      Gy
 	return a;
 }
 
+#if USE_AVX
+// Fused multiply-add (a*b + c) with a non-FMA fallback so the AVX phase path
+// still compiles when the binary is built without FMA3 (USE_FMA=0). When
+// USE_FMA=1 the build adds -mfma and the runtime CPU gate in ago_platform.cpp
+// requires the FMA bit, so emitting _mm256_fmadd_ps here is safe.
+static inline __m256 HafCpu_FmaddAvx(__m256 a, __m256 b, __m256 c)
+{
+#if USE_FMA
+	return _mm256_fmadd_ps(a, b, c);
+#else
+	return _mm256_add_ps(_mm256_mul_ps(a, b), c);
+#endif
+}
+#endif
+
 int HafCpu_Phase_U8_S16S16
 (
 	vx_uint32     dstWidth,
@@ -10338,8 +10353,8 @@ int HafCpu_Phase_U8_S16S16
 			__m256 c2Lo = _mm256_mul_ps(cLo, cLo);
 			__m256 c2Hi = _mm256_mul_ps(cHi, cHi);
 
-			__m256 polyLo = _mm256_mul_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(c2Lo, p7, p5), c2Lo, p3), c2Lo, p1), cLo);
-			__m256 polyHi = _mm256_mul_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(c2Hi, p7, p5), c2Hi, p3), c2Hi, p1), cHi);
+			__m256 polyLo = _mm256_mul_ps(HafCpu_FmaddAvx(HafCpu_FmaddAvx(HafCpu_FmaddAvx(c2Lo, p7, p5), c2Lo, p3), c2Lo, p1), cLo);
+			__m256 polyHi = _mm256_mul_ps(HafCpu_FmaddAvx(HafCpu_FmaddAvx(HafCpu_FmaddAvx(c2Hi, p7, p5), c2Hi, p3), c2Hi, p1), cHi);
 
 			__m256 angleLo = _mm256_blendv_ps(_mm256_sub_ps(ninety, polyLo), polyLo, useXLo);
 			__m256 angleHi = _mm256_blendv_ps(_mm256_sub_ps(ninety, polyHi), polyHi, useXHi);
@@ -10353,8 +10368,8 @@ int HafCpu_Phase_U8_S16S16
 			angleLo = _mm256_blendv_ps(angleLo, _mm256_sub_ps(threeSixty, angleLo), gyNegLo);
 			angleHi = _mm256_blendv_ps(angleHi, _mm256_sub_ps(threeSixty, angleHi), gyNegHi);
 
-			__m256i pLo = _mm256_cvttps_epi32(_mm256_fmadd_ps(angleLo, scale, half));
-			__m256i pHi = _mm256_cvttps_epi32(_mm256_fmadd_ps(angleHi, scale, half));
+			__m256i pLo = _mm256_cvttps_epi32(HafCpu_FmaddAvx(angleLo, scale, half));
+			__m256i pHi = _mm256_cvttps_epi32(HafCpu_FmaddAvx(angleHi, scale, half));
 			__m256i packed = _mm256_packs_epi32(pLo, pHi);
 			packed = _mm256_permute4x64_epi64(packed, 0xd8);
 			__m128i lo16 = _mm256_castsi256_si128(packed);
@@ -10372,14 +10387,14 @@ int HafCpu_Phase_U8_S16S16
 			__m256 mx = _mm256_max_ps(ax, ay);
 			__m256 c = _mm256_div_ps(mn, _mm256_add_ps(mx, eps));
 			__m256 c2 = _mm256_mul_ps(c, c);
-			__m256 poly = _mm256_mul_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(c2, p7, p5), c2, p3), c2, p1), c);
+			__m256 poly = _mm256_mul_ps(HafCpu_FmaddAvx(HafCpu_FmaddAvx(HafCpu_FmaddAvx(c2, p7, p5), c2, p3), c2, p1), c);
 			__m256 angle = _mm256_blendv_ps(_mm256_sub_ps(ninety, poly), poly, useX);
 
 			__m256 gxNeg = _mm256_castsi256_ps(_mm256_cmpgt_epi32(zero32, gx32));
 			__m256 gyNeg = _mm256_castsi256_ps(_mm256_cmpgt_epi32(zero32, gy32));
 			angle = _mm256_blendv_ps(angle, _mm256_sub_ps(oneEighty, angle), gxNeg);
 			angle = _mm256_blendv_ps(angle, _mm256_sub_ps(threeSixty, angle), gyNeg);
-			__m256i phase32 = _mm256_cvttps_epi32(_mm256_fmadd_ps(angle, scale, half));
+			__m256i phase32 = _mm256_cvttps_epi32(HafCpu_FmaddAvx(angle, scale, half));
 			__m128i phase16 = _mm_packs_epi32(_mm256_castsi256_si128(phase32), _mm256_extracti128_si256(phase32, 1));
 			__m128i phase8 = _mm_packus_epi16(phase16, phase16);
 			_mm_storel_epi64((__m128i *)(pdst + x), phase8);

--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -10294,7 +10294,6 @@ int HafCpu_Phase_U8_S16S16
 	unsigned int y = 0;
 #if USE_AVX
 	const __m256 eps = _mm256_set1_ps((float)DBL_EPSILON);
-	const __m256 two = _mm256_set1_ps(2.0f);
 	const __m256 zero = _mm256_setzero_ps();
 	const __m256 ninety = _mm256_set1_ps(90.0f);
 	const __m256 oneEighty = _mm256_set1_ps(180.0f);
@@ -10334,14 +10333,8 @@ int HafCpu_Phase_U8_S16S16
 			__m256 mnHi = _mm256_min_ps(axHi, ayHi);
 			__m256 mxHi = _mm256_max_ps(axHi, ayHi);
 
-			__m256 denLo = _mm256_add_ps(mxLo, eps);
-			__m256 denHi = _mm256_add_ps(mxHi, eps);
-			__m256 rLo = _mm256_rcp_ps(denLo);
-			__m256 rHi = _mm256_rcp_ps(denHi);
-			rLo = _mm256_mul_ps(rLo, _mm256_fnmadd_ps(denLo, rLo, two));
-			rHi = _mm256_mul_ps(rHi, _mm256_fnmadd_ps(denHi, rHi, two));
-			__m256 cLo = _mm256_mul_ps(mnLo, rLo);
-			__m256 cHi = _mm256_mul_ps(mnHi, rHi);
+			__m256 cLo = _mm256_div_ps(mnLo, _mm256_add_ps(mxLo, eps));
+			__m256 cHi = _mm256_div_ps(mnHi, _mm256_add_ps(mxHi, eps));
 			__m256 c2Lo = _mm256_mul_ps(cLo, cLo);
 			__m256 c2Hi = _mm256_mul_ps(cHi, cHi);
 
@@ -10377,10 +10370,7 @@ int HafCpu_Phase_U8_S16S16
 			__m256 useX = _mm256_cmp_ps(ay, ax, _CMP_LE_OQ);
 			__m256 mn = _mm256_min_ps(ax, ay);
 			__m256 mx = _mm256_max_ps(ax, ay);
-			__m256 den = _mm256_add_ps(mx, eps);
-			__m256 r = _mm256_rcp_ps(den);
-			r = _mm256_mul_ps(r, _mm256_fnmadd_ps(den, r, two));
-			__m256 c = _mm256_mul_ps(mn, r);
+			__m256 c = _mm256_div_ps(mn, _mm256_add_ps(mx, eps));
 			__m256 c2 = _mm256_mul_ps(c, c);
 			__m256 poly = _mm256_mul_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(_mm256_fmadd_ps(c2, p7, p5), c2, p3), c2, p1), c);
 			__m256 angle = _mm256_blendv_ps(_mm256_sub_ps(ninety, poly), poly, useX);

--- a/amd_openvx/openvx/ago/ago_internal.h
+++ b/amd_openvx/openvx/ago/ago_internal.h
@@ -56,6 +56,11 @@ THE SOFTWARE.
 #define USE_AVX 1
 #endif
 
+// Flag to enable FMA3 (fused multiply-add) instructions in primitives
+#ifndef USE_FMA
+#define USE_FMA 1
+#endif
+
 // AGO configuration
 #define USE_AGO_CANNY_SOBEL_SUPP_THRESHOLD    0 // 0:seperate-sobel-and-nonmaxsupression 1:combine-sobel-and-nonmaxsupression
 #define AGO_MEMORY_ALLOC_EXTRA_PADDING       64 // extra bytes to the left and right of buffer allocations

--- a/amd_openvx/openvx/ago/ago_platform.cpp
+++ b/amd_openvx/openvx/ago/ago_platform.cpp
@@ -62,7 +62,7 @@ static uint64_t agoXgetbv(uint32_t index)
 #pragma comment(lib, "OpenCL.lib")
 #endif
 
-// Mirror the USE_AVX / USE_BMI2 compile-time switches from ago_internal.h
+// Mirror the USE_AVX / USE_FMA / USE_BMI2 compile-time switches from ago_internal.h
 // so the hardware-support check below can reflect the *actual* minimum ISA
 // emitted by this binary. Both ago_internal.h and the block here use the
 // same `#ifndef … #define … 1 … #endif` guard, so a single
@@ -71,6 +71,9 @@ static uint64_t agoXgetbv(uint32_t index)
 // is included down below in the !_WIN32 section).
 #ifndef USE_AVX
 #define USE_AVX 1
+#endif
+#ifndef USE_FMA
+#define USE_FMA 1
 #endif
 #ifndef USE_BMI2
 #define USE_BMI2 1
@@ -82,8 +85,8 @@ bool agoIsCpuHardwareSupported()
 	// instruction set the binary was compiled to emit. Previously this
 	// only checked SSE4.2, so on a SSE4.2-only Nehalem-class CPU we
 	// would happily create a vx_context and then SIGILL on the first
-	// AVX2 kernel invocation. With USE_AVX/USE_BMI2 enabled at compile
-	// time, the corresponding runtime feature bits are now hard
+	// AVX2 kernel invocation. With USE_AVX/USE_FMA/USE_BMI2 enabled at
+	// compile time, the corresponding runtime feature bits are now hard
 	// preconditions. f.avx2 already AND-folds the OSXSAVE/XCR0 check
 	// in agoGetCpuFeatures() so an OS that disabled AVX state save also
 	// correctly fails this gate.
@@ -91,6 +94,9 @@ bool agoIsCpuHardwareSupported()
 	if (!f.sse42) return false;
 #if USE_AVX
 	if (!f.avx2) return false;
+#endif
+#if USE_FMA
+	if (!f.fma) return false;
 #endif
 #if USE_BMI2
 	if (!f.bmi2) return false;
@@ -113,11 +119,15 @@ const ago_cpu_features_t & agoGetCpuFeatures()
 			agoCpuid(CPUInfo, 1, 0);
 			f.sse42 = (CPUInfo[2] & (1 << 20)) != 0;
 			bool cpuAvx = (CPUInfo[2] & (1 << 28)) != 0;
+			bool cpuFma = (CPUInfo[2] & (1 << 12)) != 0;
 			bool osxsave = (CPUInfo[2] & (1 << 27)) != 0;
 			if (cpuAvx && osxsave) {
 				uint64_t xcr0 = agoXgetbv(0);
 				osAvx = (xcr0 & 0x6) == 0x6;
 				f.avx = osAvx;
+				// FMA3 operates on YMM registers, so it requires the same
+				// OS AVX-state-save support as AVX itself.
+				f.fma = osAvx && cpuFma;
 			}
 		}
 

--- a/amd_openvx/openvx/ago/ago_platform.h
+++ b/amd_openvx/openvx/ago/ago_platform.h
@@ -132,6 +132,7 @@ typedef struct {
 	bool sse42;
 	bool avx;
 	bool avx2;
+	bool fma;
 	bool bmi2;
 	bool avx512f;
 	bool avx512bw;


### PR DESCRIPTION
## Motivation

Fix phase performance in OpenVX CPU

## Technical Details

* All AVX2 CPUs have FMA3, so -mfma alongside -mavx2 is safe. The AVX path is Linux-only here (Windows compiles the scalar fallback), so MSVC is unaffected.

* FMA changes rounding very slightly vs. the old separate mul/add, but it now exactly matches OpenCV's reference path and stays within the Phase conformance tolerance (output is quantized to U8 with ± tolerance).


## Test Plan

CTS and performance

## Test Result

All tests are passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
