### PR TITLE
OpenCL - Fix CI failures

### DIFF
--- a/amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp
@@ -612,14 +612,14 @@ int HafGpu_NonLinearFilter_3x3_ANY_U1(AgoNode * node)
 		int op = (node->akernel->id == VX_KERNEL_AMD_DILATE_U8_U1_3x3 || node->akernel->id == VX_KERNEL_AMD_DILATE_U1_U1_3x3) ? '|' : '&';
 		snprintf(item, sizeof(item),
 			OPENCL_FORMAT(
-			"  x = (x >> 3) - 1;\n"
+			"  x = x >> 3;\n"
 			"  p += y * %d + x;\n" // stride
 			"  __global uchar *p0 = p - %d;\n" // stride
 			"  __global uchar *p1 = p;\n"
 			"  __global uchar *p2 = p + %d;\n" // stride
-			"  uint L0 = (uint)p0[0] | ((uint)p0[1] << 8) | ((uint)p0[2] << 16) | ((uint)p0[3] << 24);\n"
-			"  uint L1 = (uint)p1[0] | ((uint)p1[1] << 8) | ((uint)p1[2] << 16) | ((uint)p1[3] << 24);\n"
-			"  uint L2 = (uint)p2[0] | ((uint)p2[1] << 8) | ((uint)p2[2] << 16) | ((uint)p2[3] << 24);\n"
+			"  uint L0 = (uint)p0[-1] | ((uint)p0[0] << 8) | ((uint)p0[1] << 16) | ((uint)p0[2] << 24);\n"
+			"  uint L1 = (uint)p1[-1] | ((uint)p1[0] << 8) | ((uint)p1[1] << 16) | ((uint)p1[2] << 24);\n"
+			"  uint L2 = (uint)p2[-1] | ((uint)p2[0] << 8) | ((uint)p2[1] << 16) | ((uint)p2[2] << 24);\n"
 			"  L0 = L0 %c (L0 >> 1) %c (L0 << 1);\n" // op, op
 			"  L1 = L1 %c (L1 >> 1) %c (L1 << 1);\n" // op, op
 			"  L2 = L2 %c (L2 >> 1) %c (L2 << 1);\n" // op, op

--- a/amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp
@@ -611,14 +611,15 @@ int HafGpu_NonLinearFilter_3x3_ANY_U1(AgoNode * node)
 		node->akernel->id == VX_KERNEL_AMD_ERODE_U1_U1_3x3) {
 		int op = (node->akernel->id == VX_KERNEL_AMD_DILATE_U8_U1_3x3 || node->akernel->id == VX_KERNEL_AMD_DILATE_U1_U1_3x3) ? '|' : '&';
 		snprintf(item, sizeof(item),
-			// TBD: this code segment uses risky 32-bit loads without 32-bit alignment
-			//      it works great on our hardware though it doesn't follow OpenCL rules
 			OPENCL_FORMAT(
 			"  x = (x >> 3) - 1;\n"
 			"  p += y * %d + x;\n" // stride
-			"  uint L0 = *(__global uint *)&p[-%d];\n" //  stride
-			"  uint L1 = *(__global uint *) p;\n"
-			"  uint L2 = *(__global uint *)&p[%d];\n" //  stride
+			"  __global uchar *p0 = p - %d;\n" // stride
+			"  __global uchar *p1 = p;\n"
+			"  __global uchar *p2 = p + %d;\n" // stride
+			"  uint L0 = (uint)p0[0] | ((uint)p0[1] << 8) | ((uint)p0[2] << 16) | ((uint)p0[3] << 24);\n"
+			"  uint L1 = (uint)p1[0] | ((uint)p1[1] << 8) | ((uint)p1[2] << 16) | ((uint)p1[3] << 24);\n"
+			"  uint L2 = (uint)p2[0] | ((uint)p2[1] << 8) | ((uint)p2[2] << 16) | ((uint)p2[3] << 24);\n"
 			"  L0 = L0 %c (L0 >> 1) %c (L0 << 1);\n" // op, op
 			"  L1 = L1 %c (L1 >> 1) %c (L1 << 1);\n" // op, op
 			"  L2 = L2 %c (L2 >> 1) %c (L2 << 1);\n" // op, op

--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -19385,24 +19385,25 @@ int agoKernel_WarpPerspective_U8_U8_Nearest(AgoNode * node, AgoKernelCommand cmd
 #if ENABLE_OPENCL
     else if (cmd == ago_kernel_cmd_opencl_codegen) {
         status = VX_SUCCESS;
+        agoCodeGenOpenCL_SampleWithConstBorder(node->opencl_code);
         char textBuffer[4096];
         snprintf(textBuffer, sizeof(textBuffer), OPENCL_FORMAT(
             "void %s(U8x8 * r, uint x, uint y, __global uchar * p, uint stride, uint width, uint height, ago_perspective_matrix_t matrix)\n"
             "{\n"
             "  U8x8 rv;\n"
-            "  float sx, sy, sz, isz;\n"
+            "  float sx, sy, sz, isz; uint v;\n"
             "  float dx = (float)x, dy = (float)y;\n"
             "  sx = mad(dy, matrix.M[1][0], matrix.M[2][0]); sx = mad(dx, matrix.M[0][0], sx);\n"
             "  sy = mad(dy, matrix.M[1][1], matrix.M[2][1]); sy = mad(dx, matrix.M[0][1], sy);\n"
             "  sz = mad(dy, matrix.M[1][2], matrix.M[2][2]); sz = mad(dx, matrix.M[0][2], sz);\n"
-            "  isz = 1.0f / sz; rv.s0 = p[(int)mad24(stride, (uint)(sy*isz), (uint)(sx*isz))];\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; rv.s0 |= p[(int)mad24(stride, (uint)(sy*isz), (uint)(sx*isz))] << 8;\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; rv.s0 |= p[(int)mad24(stride, (uint)(sy*isz), (uint)(sx*isz))] << 16;\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; rv.s0 |= p[(int)mad24(stride, (uint)(sy*isz), (uint)(sx*isz))] << 24;\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; rv.s1  = p[(int)mad24(stride, (uint)(sy*isz), (uint)(sx*isz))];\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; rv.s1 |= p[(int)mad24(stride, (uint)(sy*isz), (uint)(sx*isz))] << 8;\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; rv.s1 |= p[(int)mad24(stride, (uint)(sy*isz), (uint)(sx*isz))] << 16;\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; rv.s1 |= p[(int)mad24(stride, (uint)(sy*isz), (uint)(sx*isz))] << 24;\n"
+            "  isz = 1.0f / sz; v = SampleWithConstBorder(p, (int)(sx*isz), (int)(sy*isz), width, height, stride, 0); rv.s0 = v;\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; v = SampleWithConstBorder(p, (int)(sx*isz), (int)(sy*isz), width, height, stride, 0); rv.s0 |= v << 8;\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; v = SampleWithConstBorder(p, (int)(sx*isz), (int)(sy*isz), width, height, stride, 0); rv.s0 |= v << 16;\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; v = SampleWithConstBorder(p, (int)(sx*isz), (int)(sy*isz), width, height, stride, 0); rv.s0 |= v << 24;\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; v = SampleWithConstBorder(p, (int)(sx*isz), (int)(sy*isz), width, height, stride, 0); rv.s1 = v;\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; v = SampleWithConstBorder(p, (int)(sx*isz), (int)(sy*isz), width, height, stride, 0); rv.s1 |= v << 8;\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; v = SampleWithConstBorder(p, (int)(sx*isz), (int)(sy*isz), width, height, stride, 0); rv.s1 |= v << 16;\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; v = SampleWithConstBorder(p, (int)(sx*isz), (int)(sy*isz), width, height, stride, 0); rv.s1 |= v << 24;\n"
             "  *r = rv;\n"
             "}\n"
             ), node->opencl_name);
@@ -19595,8 +19596,10 @@ int agoKernel_WarpPerspective_U8_U8_Bilinear(AgoNode * node, AgoKernelCommand cm
 #if ENABLE_OPENCL
     else if (cmd == ago_kernel_cmd_opencl_codegen) {
         status = VX_SUCCESS;
+        agoCodeGenOpenCL_SampleWithConstBorder(node->opencl_code);
         agoCodeGenOpenCL_BilinearSample(node->opencl_code);
-        agoCodeGenOpenCL_BilinearSampleFXY(node->opencl_code);
+        agoCodeGenOpenCL_BilinearSampleWithConstBorder(node->opencl_code);
+        agoCodeGenOpenCL_BilinearSampleFXYConstant(node->opencl_code);
         char textBuffer[4096];
         snprintf(textBuffer, sizeof(textBuffer), OPENCL_FORMAT(
             "void %s(U8x8 * r, uint x, uint y, __global uchar * p, uint stride, uint width, uint height, ago_perspective_matrix_t matrix)\n"
@@ -19607,15 +19610,15 @@ int agoKernel_WarpPerspective_U8_U8_Bilinear(AgoNode * node, AgoKernelCommand cm
             "  sx = mad(dy, matrix.M[1][0], matrix.M[2][0]); sx = mad(dx, matrix.M[0][0], sx);\n"
             "  sy = mad(dy, matrix.M[1][1], matrix.M[2][1]); sy = mad(dx, matrix.M[0][1], sy);\n"
             "  sz = mad(dy, matrix.M[1][2], matrix.M[2][2]); sz = mad(dx, matrix.M[0][2], sz);\n"
-            "  isz = 1.0f / sz; f.s0 = BilinearSampleFXY(p, stride, sx*isz, sy*isz);\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s1 = BilinearSampleFXY(p, stride, sx*isz, sy*isz);\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s2 = BilinearSampleFXY(p, stride, sx*isz, sy*isz);\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s3 = BilinearSampleFXY(p, stride, sx*isz, sy*isz);\n"
+            "  isz = 1.0f / sz; f.s0 = BilinearSampleFXYConstant(p, stride, width, height, sx*isz, sy*isz, 0);\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s1 = BilinearSampleFXYConstant(p, stride, width, height, sx*isz, sy*isz, 0);\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s2 = BilinearSampleFXYConstant(p, stride, width, height, sx*isz, sy*isz, 0);\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s3 = BilinearSampleFXYConstant(p, stride, width, height, sx*isz, sy*isz, 0);\n"
             "  rv.s0 = amd_pack(f);\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s0 = BilinearSampleFXY(p, stride, sx*isz, sy*isz);\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s1 = BilinearSampleFXY(p, stride, sx*isz, sy*isz);\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s2 = BilinearSampleFXY(p, stride, sx*isz, sy*isz);\n"
-            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s3 = BilinearSampleFXY(p, stride, sx*isz, sy*isz);\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s0 = BilinearSampleFXYConstant(p, stride, width, height, sx*isz, sy*isz, 0);\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s1 = BilinearSampleFXYConstant(p, stride, width, height, sx*isz, sy*isz, 0);\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s2 = BilinearSampleFXYConstant(p, stride, width, height, sx*isz, sy*isz, 0);\n"
+            "  sx += matrix.M[0][0]; sy += matrix.M[0][1]; sz += matrix.M[0][2]; isz = 1.0f / sz; f.s3 = BilinearSampleFXYConstant(p, stride, width, height, sx*isz, sy*isz, 0);\n"
             "  rv.s1 = amd_pack(f);\n"
             "  *r = rv;\n"
             "}\n"

--- a/amd_openvx/openvx/ago/ago_util.cpp
+++ b/amd_openvx/openvx/ago/ago_util.cpp
@@ -3403,7 +3403,9 @@ AgoContext::AgoContext()
     memset(&immediate_border_mode, 0, sizeof(immediate_border_mode));
     memset(&extensions, 0, sizeof(extensions));
 #if ENABLE_OPENCL
-    memset(&opencl_extensions, 0, sizeof(opencl_extensions));
+    // NOTE: opencl_extensions is a std::string and is already default-constructed
+    //       to empty; memset() on it corrupts the object (UB) and breaks OpenCL
+    //       context init for every graph, so it must NOT be memset here.
     memset(&opencl_device_list, 0, sizeof(opencl_device_list));
     memset(&opencl_build_options, 0, sizeof(opencl_build_options));
 #endif

--- a/amd_openvx/openvx/ago/ago_util.cpp
+++ b/amd_openvx/openvx/ago/ago_util.cpp
@@ -1510,17 +1510,53 @@ int agoGetDataFromDescription(AgoContext * acontext, AgoGraph * agraph, AgoData 
         data->ref.type = VX_TYPE_THRESHOLD;
         const char *s = strstr(desc, ","); if (!s) return -1;
         char thresh_type[64];
-        //char data_type[64];
-        uint32_t input_format, output_format;
         memcpy(thresh_type, desc, s - desc); thresh_type[s - desc] = 0;
-        s = strstr(s, ",");
-        input_format = stoi(s+1);
-        s = strstr(s+1, ",");
-        output_format = stoi(s+1);
         data->u.thr.thresh_type = agoName2Enum(thresh_type);
-        //data->u.thr.data_type = agoName2Enum(data_type);
-        data->u.thr.input_format = (vx_df_image)input_format;
-        data->u.thr.output_format = (vx_df_image)output_format;
+        s++;
+        const char *init = strchr(s, ':');
+        const char *next = strchr(s, ',');
+        if (next && (!init || next < init)) {
+            char *end = nullptr;
+            unsigned long input_format = strtoul(s, &end, 10);
+            if (end != next) return -1;
+            unsigned long output_format = strtoul(next + 1, &end, 10);
+            if (end == next + 1 || (*end && *end != ':' && *end != ',')) return -1;
+            data->u.thr.input_format = (vx_df_image)input_format;
+            data->u.thr.output_format = (vx_df_image)output_format;
+        }
+        else {
+            char data_type[64];
+            strncpy(data_type, s, sizeof(data_type) - 1);
+            data_type[sizeof(data_type) - 1] = 0;
+            char *init_pos = strchr(data_type, ':');
+            if (init_pos) *init_pos = 0;
+            data->u.thr.data_type = agoName2Enum(data_type);
+            if (data->u.thr.data_type == VX_TYPE_UINT8 || data->u.thr.data_type == VX_TYPE_INT8 || data->u.thr.data_type == VX_TYPE_BOOL) {
+                data->u.thr.input_format = VX_DF_IMAGE_U8;
+                data->u.thr.output_format = (data->u.thr.data_type == VX_TYPE_BOOL) ? VX_DF_IMAGE_U1 : VX_DF_IMAGE_U8;
+            }
+            else if (data->u.thr.data_type == VX_TYPE_INT16) {
+                data->u.thr.input_format = VX_DF_IMAGE_S16;
+                data->u.thr.output_format = VX_DF_IMAGE_U8;
+            }
+            else if (data->u.thr.data_type == VX_TYPE_UINT16) {
+                data->u.thr.input_format = VX_DF_IMAGE_U16;
+                data->u.thr.output_format = VX_DF_IMAGE_U8;
+            }
+            else if (data->u.thr.data_type == VX_TYPE_INT32) {
+                data->u.thr.input_format = VX_DF_IMAGE_S32;
+                data->u.thr.output_format = VX_DF_IMAGE_U8;
+            }
+            else if (data->u.thr.data_type == VX_TYPE_UINT32) {
+                data->u.thr.input_format = VX_DF_IMAGE_U32;
+                data->u.thr.output_format = VX_DF_IMAGE_U8;
+            }
+        }
+        if (!data->u.thr.data_type) {
+            if (data->u.thr.output_format == VX_DF_IMAGE_U1) data->u.thr.data_type = VX_TYPE_BOOL;
+            else if (data->u.thr.input_format == VX_DF_IMAGE_S16) data->u.thr.data_type = VX_TYPE_INT16;
+            else data->u.thr.data_type = VX_TYPE_UINT8;
+        }
 
         if (!data->u.thr.thresh_type || !data->u.thr.input_format || !data->u.thr.output_format) return -1;
         /*if (data->u.thr.data_type != VX_TYPE_UINT8 && data->u.thr.data_type != VX_TYPE_UINT16 && data->u.thr.data_type != VX_TYPE_INT16) {

--- a/tests/openvx_api_tests/threshold_query/threshold_query_api.cpp
+++ b/tests/openvx_api_tests/threshold_query/threshold_query_api.cpp
@@ -52,36 +52,38 @@ THE SOFTWARE.
 } while(0)
 
 // ---------------------------------------------------------------------------
-// Test 1: vxCreateThresholdForImage with various format combinations
-// Note: The deprecated vxCreateThreshold() has a known stoi bug in this
-//       codebase (enum name passed where numeric image format expected),
-//       so we use vxCreateThresholdForImage() which is the 1.3 API.
+// Test 1: vxCreateThreshold deprecated API coverage
 // ---------------------------------------------------------------------------
 static int test_vxCreateThreshold_deprecated(vx_context context) {
     int errors = 0;
-    printf("\n=== Test 1: vxCreateThresholdForImage (various formats) ===\n");
+    printf("\n=== Test 1: vxCreateThreshold (deprecated API) ===\n");
 
-    // Binary threshold: U8 input, U8 output
-    vx_threshold thr_u8 = vxCreateThresholdForImage(context, VX_THRESHOLD_TYPE_BINARY, VX_DF_IMAGE_U8, VX_DF_IMAGE_U8);
-    CHECK_NOT_NULL(thr_u8, "vxCreateThresholdForImage(BINARY, U8, U8)");
+    vx_threshold thr_u8 = vxCreateThreshold(context, VX_THRESHOLD_TYPE_BINARY, VX_TYPE_UINT8);
+    CHECK_NOT_NULL(thr_u8, "vxCreateThreshold(BINARY, UINT8)");
 
-    // Range threshold: S16 input, U8 output
-    vx_threshold thr_s16 = vxCreateThresholdForImage(context, VX_THRESHOLD_TYPE_RANGE, VX_DF_IMAGE_S16, VX_DF_IMAGE_U8);
-    CHECK_NOT_NULL(thr_s16, "vxCreateThresholdForImage(RANGE, S16, U8)");
+    if (thr_u8) {
+        vx_enum data_type = 0;
+        CHECK_STATUS(vxQueryThreshold(thr_u8, VX_THRESHOLD_ATTRIBUTE_DATA_TYPE, &data_type, sizeof(data_type)));
+        if (data_type != VX_TYPE_UINT8) {
+            printf("  FAIL: Expected UINT8 data type, got 0x%08x\n", data_type);
+            errors++;
+        }
+    }
 
-    // Binary threshold: U8 input, U1 output
-    vx_threshold thr_u1 = vxCreateThresholdForImage(context, VX_THRESHOLD_TYPE_BINARY, VX_DF_IMAGE_U8, VX_DF_IMAGE_U1);
-    CHECK_NOT_NULL(thr_u1, "vxCreateThresholdForImage(BINARY, U8, U1)");
+    vx_threshold thr_s16 = vxCreateThreshold(context, VX_THRESHOLD_TYPE_RANGE, VX_TYPE_INT16);
+    CHECK_NOT_NULL(thr_s16, "vxCreateThreshold(RANGE, INT16)");
 
-    // Range threshold: U8 input, U8 output
-    vx_threshold thr_range_u8 = vxCreateThresholdForImage(context, VX_THRESHOLD_TYPE_RANGE, VX_DF_IMAGE_U8, VX_DF_IMAGE_U8);
-    CHECK_NOT_NULL(thr_range_u8, "vxCreateThresholdForImage(RANGE, U8, U8)");
+    if (thr_s16) {
+        vx_enum data_type = 0;
+        CHECK_STATUS(vxQueryThreshold(thr_s16, VX_THRESHOLD_ATTRIBUTE_DATA_TYPE, &data_type, sizeof(data_type)));
+        if (data_type != VX_TYPE_INT16) {
+            printf("  FAIL: Expected INT16 data type, got 0x%08x\n", data_type);
+            errors++;
+        }
+    }
 
-    // Release all thresholds
-    if (thr_u8)       CHECK_STATUS(vxReleaseThreshold(&thr_u8));
-    if (thr_s16)      CHECK_STATUS(vxReleaseThreshold(&thr_s16));
-    if (thr_u1)       CHECK_STATUS(vxReleaseThreshold(&thr_u1));
-    if (thr_range_u8) CHECK_STATUS(vxReleaseThreshold(&thr_range_u8));
+    if (thr_u8)  CHECK_STATUS(vxReleaseThreshold(&thr_u8));
+    if (thr_s16) CHECK_STATUS(vxReleaseThreshold(&thr_s16));
 
     return errors;
 }

--- a/tests/openvx_conformance_tests/runConformanceTests.py
+++ b/tests/openvx_conformance_tests/runConformanceTests.py
@@ -142,6 +142,29 @@ def resolve_cts_dir(directory_arg: str) -> Path:
     return (base / "mivisionx-conformance").resolve()
 
 
+def path_is_relative_to(path: Path, parent: Path) -> bool:
+    """Return True when *path* is inside *parent* (or equal to it)."""
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def move_cwd_out_of_cts_dir(cts_dir: Path, source_root: Path) -> None:
+    """Avoid deleting the process current directory during conformance cleanup."""
+    try:
+        cwd = Path.cwd().resolve()
+    except FileNotFoundError:
+        os.chdir(source_root)
+        log.info("Current working directory no longer exists; switched to %s", source_root)
+        return
+
+    if path_is_relative_to(cwd, cts_dir):
+        os.chdir(source_root)
+        log.info("Current working directory is inside %s; switched to %s", cts_dir, source_root)
+
+
 # ---------------------------------------------------------------------------
 # Subprocess wrappers
 # ---------------------------------------------------------------------------
@@ -536,6 +559,7 @@ def main() -> int:
 
     cts_dir = resolve_cts_dir(args.directory)
     source_root = (Path(__file__).resolve().parent / ".." / "..").resolve()
+    move_cwd_out_of_cts_dir(cts_dir, source_root)
 
     # -- Clean previous run ---------------------------------------------------
     if cts_dir.exists() and not args.no_clean:
@@ -580,14 +604,13 @@ def main() -> int:
     platform_name = sanitize_filename(platform.platform())
     file_dtstr = datetime.now().strftime("%Y%m%d")
     report_filename = f"system_info_report_{platform_name}_{file_dtstr}.md"
-    report_path = Path(report_filename).resolve()
+    report_path = cts_dir / report_filename
     write_system_report(
         report_path,
         backend_type=backend_type,
         openvx_lib_dirs=openvx_lib_dirs,
         lib_type=lib_type,
     )
-    shutil.copy2(report_path, cts_dir / report_path.name)
     print(f"\nSTATUS: Output Report File - {report_path}")
 
     # -- CTS repo + build dirs ------------------------------------------------
@@ -648,7 +671,7 @@ def main() -> int:
                 failures.append("HOST (%s)" % describe_returncode(rc))
             host_data = report_path.read_text(encoding="utf-8")
             cts_log_data = out_md.read_text(encoding="utf-8")
-            Path("HOST_Conformance_Logs.md").write_text(host_data + "\n\n" + cts_log_data, encoding="utf-8")
+            (cts_dir / "HOST_Conformance_Logs.md").write_text(host_data + "\n\n" + cts_log_data, encoding="utf-8")
 
         if backend_type in ("ALL", "OCL"):
             warn_if_missing_cts_module(cts_ocl_build, "test-testmodule")
@@ -668,7 +691,7 @@ def main() -> int:
             combined = ocl_data + "\n\n" + "\n\n".join(
                 p.read_text(encoding="utf-8") for p in md_paths if p.exists()
             )
-            Path("OCL_Conformance_Logs.md").write_text(combined, encoding="utf-8")
+            (cts_dir / "OCL_Conformance_Logs.md").write_text(combined, encoding="utf-8")
 
         if backend_type in ("ALL", "HIP"):
             warn_if_missing_cts_module(cts_hip_build, "test-testmodule")
@@ -688,7 +711,7 @@ def main() -> int:
             combined = hip_data + "\n\n" + "\n\n".join(
                 p.read_text(encoding="utf-8") for p in md_paths if p.exists()
             )
-            Path("HIP_Conformance_Logs.md").write_text(combined, encoding="utf-8")
+            (cts_dir / "HIP_Conformance_Logs.md").write_text(combined, encoding="utf-8")
 
     if failures:
         log.error("CTS failures: %s", ", ".join(failures))


### PR DESCRIPTION
## Motivation

Fix vxCreateThresholdForImage

## Technical Details

OpenCL-side fixes for that failure cluster:

* amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp: replaced the U1 morphology generated kernel’s unaligned __global uint* loads with explicit byte assembly. This targets the four U1 dilate/erode aborts.
* amd_openvx/openvx/ago/ago_kernel_api.cpp: changed non-constant warp-perspective OpenCL generation to use zero-border guarded sampling, matching the CPU path’s behavior and avoiding out-of-bounds reads. This targets the two warp-perspective aborts.

## Test Plan

GitHub workflow + MathCI

## Test Result

OpenCL tests on MathCI should pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
