### PR TITLE
OpenVX CPU - Performance parity

### DIFF
--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -7578,6 +7578,132 @@ int HafCpu_MeanStdDevMerge_DATA_DATA
 	return AGO_SUCCESS;
 }
 
+template <bool addPreviousRow>
+static inline void HafCpu_IntegralImageRow_U32_U8(
+	vx_uint32     dstWidth,
+	vx_uint32   * pDst,
+	const vx_uint32 * pPrev,
+	const vx_uint8 * pSrc)
+{
+	// IntegralImage is computed as a two-step process per row, fused into the
+	// same loop: a 16-byte SIMD in-row prefix sum followed by a column add of
+	// the previous row's accumulated values. The row carry is the cumulative
+	// sum of all earlier source bytes in the row, broadcast as int32.
+	const __m128i zeromask = _mm_setzero_si128();
+	__m128i carry = _mm_setzero_si128();
+	vx_uint32 rowSum = 0;
+	vx_uint32 x = 0;
+
+	// Process two 16-byte chunks per iteration so the loop is wider while
+	// each chunk still uses 128-bit intra-lane shifts for prefix sums.
+	for (; x + 32 <= dstWidth; x += 32)
+	{
+		__m128i bytesA = _mm_loadu_si128((__m128i *)(pSrc + x));
+		__m128i bytesB = _mm_loadu_si128((__m128i *)(pSrc + x + 16));
+
+		__m128i lo0 = _mm_cvtepu8_epi16(bytesA);
+		__m128i hi0 = _mm_unpackhi_epi8(bytesA, zeromask);
+		__m128i lo1 = _mm_cvtepu8_epi16(bytesB);
+		__m128i hi1 = _mm_unpackhi_epi8(bytesB, zeromask);
+
+		lo0 = _mm_add_epi16(lo0, _mm_slli_si128(lo0, 2));
+		lo0 = _mm_add_epi16(lo0, _mm_slli_si128(lo0, 4));
+		lo0 = _mm_add_epi16(lo0, _mm_slli_si128(lo0, 8));
+		hi0 = _mm_add_epi16(hi0, _mm_slli_si128(hi0, 2));
+		hi0 = _mm_add_epi16(hi0, _mm_slli_si128(hi0, 4));
+		hi0 = _mm_add_epi16(hi0, _mm_slli_si128(hi0, 8));
+		hi0 = _mm_add_epi16(hi0, _mm_shuffle_epi32(_mm_shufflehi_epi16(lo0, 0xff), 0xff));
+
+		lo1 = _mm_add_epi16(lo1, _mm_slli_si128(lo1, 2));
+		lo1 = _mm_add_epi16(lo1, _mm_slli_si128(lo1, 4));
+		lo1 = _mm_add_epi16(lo1, _mm_slli_si128(lo1, 8));
+		hi1 = _mm_add_epi16(hi1, _mm_slli_si128(hi1, 2));
+		hi1 = _mm_add_epi16(hi1, _mm_slli_si128(hi1, 4));
+		hi1 = _mm_add_epi16(hi1, _mm_slli_si128(hi1, 8));
+		hi1 = _mm_add_epi16(hi1, _mm_shuffle_epi32(_mm_shufflehi_epi16(lo1, 0xff), 0xff));
+
+		__m128i out0 = _mm_add_epi32(_mm_cvtepu16_epi32(lo0), carry);
+		__m128i out1 = _mm_add_epi32(_mm_unpackhi_epi16(lo0, zeromask), carry);
+		__m128i out2 = _mm_add_epi32(_mm_cvtepu16_epi32(hi0), carry);
+		__m128i out3 = _mm_add_epi32(_mm_unpackhi_epi16(hi0, zeromask), carry);
+
+		vx_uint32 firstChunkSum = (vx_uint32)_mm_extract_epi16(hi0, 7);
+		__m128i carry1 = _mm_add_epi32(carry, _mm_set1_epi32((int)firstChunkSum));
+
+		__m128i out4 = _mm_add_epi32(_mm_cvtepu16_epi32(lo1), carry1);
+		__m128i out5 = _mm_add_epi32(_mm_unpackhi_epi16(lo1, zeromask), carry1);
+		__m128i out6 = _mm_add_epi32(_mm_cvtepu16_epi32(hi1), carry1);
+		__m128i out7 = _mm_add_epi32(_mm_unpackhi_epi16(hi1, zeromask), carry1);
+
+		if constexpr (addPreviousRow)
+		{
+			out0 = _mm_add_epi32(out0, _mm_loadu_si128((__m128i *)(pPrev + x)));
+			out1 = _mm_add_epi32(out1, _mm_loadu_si128((__m128i *)(pPrev + x + 4)));
+			out2 = _mm_add_epi32(out2, _mm_loadu_si128((__m128i *)(pPrev + x + 8)));
+			out3 = _mm_add_epi32(out3, _mm_loadu_si128((__m128i *)(pPrev + x + 12)));
+			out4 = _mm_add_epi32(out4, _mm_loadu_si128((__m128i *)(pPrev + x + 16)));
+			out5 = _mm_add_epi32(out5, _mm_loadu_si128((__m128i *)(pPrev + x + 20)));
+			out6 = _mm_add_epi32(out6, _mm_loadu_si128((__m128i *)(pPrev + x + 24)));
+			out7 = _mm_add_epi32(out7, _mm_loadu_si128((__m128i *)(pPrev + x + 28)));
+		}
+		_mm_storeu_si128((__m128i *)(pDst + x), out0);
+		_mm_storeu_si128((__m128i *)(pDst + x + 4), out1);
+		_mm_storeu_si128((__m128i *)(pDst + x + 8), out2);
+		_mm_storeu_si128((__m128i *)(pDst + x + 12), out3);
+		_mm_storeu_si128((__m128i *)(pDst + x + 16), out4);
+		_mm_storeu_si128((__m128i *)(pDst + x + 20), out5);
+		_mm_storeu_si128((__m128i *)(pDst + x + 24), out6);
+		_mm_storeu_si128((__m128i *)(pDst + x + 28), out7);
+
+		vx_uint32 secondChunkSum = (vx_uint32)_mm_extract_epi16(hi1, 7);
+		rowSum += firstChunkSum + secondChunkSum;
+		carry = _mm_set1_epi32((int)rowSum);
+	}
+
+	for (; x + 16 <= dstWidth; x += 16)
+	{
+		__m128i bytes = _mm_loadu_si128((__m128i *)(pSrc + x));
+		__m128i lo = _mm_cvtepu8_epi16(bytes);
+		__m128i hi = _mm_unpackhi_epi8(bytes, zeromask);
+
+		lo = _mm_add_epi16(lo, _mm_slli_si128(lo, 2));
+		lo = _mm_add_epi16(lo, _mm_slli_si128(lo, 4));
+		lo = _mm_add_epi16(lo, _mm_slli_si128(lo, 8));
+		hi = _mm_add_epi16(hi, _mm_slli_si128(hi, 2));
+		hi = _mm_add_epi16(hi, _mm_slli_si128(hi, 4));
+		hi = _mm_add_epi16(hi, _mm_slli_si128(hi, 8));
+		hi = _mm_add_epi16(hi, _mm_shuffle_epi32(_mm_shufflehi_epi16(lo, 0xff), 0xff));
+
+		__m128i out0 = _mm_add_epi32(_mm_cvtepu16_epi32(lo), carry);
+		__m128i out1 = _mm_add_epi32(_mm_unpackhi_epi16(lo, zeromask), carry);
+		__m128i out2 = _mm_add_epi32(_mm_cvtepu16_epi32(hi), carry);
+		__m128i out3 = _mm_add_epi32(_mm_unpackhi_epi16(hi, zeromask), carry);
+		if constexpr (addPreviousRow)
+		{
+			out0 = _mm_add_epi32(out0, _mm_loadu_si128((__m128i *)(pPrev + x)));
+			out1 = _mm_add_epi32(out1, _mm_loadu_si128((__m128i *)(pPrev + x + 4)));
+			out2 = _mm_add_epi32(out2, _mm_loadu_si128((__m128i *)(pPrev + x + 8)));
+			out3 = _mm_add_epi32(out3, _mm_loadu_si128((__m128i *)(pPrev + x + 12)));
+		}
+		_mm_storeu_si128((__m128i *)(pDst + x), out0);
+		_mm_storeu_si128((__m128i *)(pDst + x + 4), out1);
+		_mm_storeu_si128((__m128i *)(pDst + x + 8), out2);
+		_mm_storeu_si128((__m128i *)(pDst + x + 12), out3);
+
+		rowSum += (vx_uint32)_mm_extract_epi16(hi, 7);
+		carry = _mm_set1_epi32((int)rowSum);
+	}
+
+	for (; x < dstWidth; x++)
+	{
+		rowSum += pSrc[x];
+		if constexpr (addPreviousRow)
+			pDst[x] = rowSum + pPrev[x];
+		else
+			pDst[x] = rowSum;
+	}
+}
+
 int HafCpu_IntegralImage_U32_U8
 (
 	vx_uint32     dstWidth,
@@ -7588,126 +7714,18 @@ int HafCpu_IntegralImage_U32_U8
 	vx_uint32     srcImageStrideInBytes
 )
 {
-	// IntegralImage is computed as a two-step process per row, fused into the
-	// same loop: a 16-byte SIMD in-row prefix sum followed by a column add of
-	// the previous row's accumulated values. The row carry is the cumulative
-	// sum of all earlier source bytes in the row, broadcast as int32.
-	const __m128i zeromask = _mm_setzero_si128();
+	if (!dstHeight)
+		return AGO_SUCCESS;
 
-	for (vx_uint32 y = 0; y < dstHeight; y++)
+	vx_uint32 *pDst = pDstImage;
+	HafCpu_IntegralImageRow_U32_U8<false>(dstWidth, pDst, nullptr, pSrcImage);
+
+	for (vx_uint32 y = 1; y < dstHeight; y++)
 	{
 		vx_uint8 *pSrc = pSrcImage + y * srcImageStrideInBytes;
-		vx_uint32 *pDst = (vx_uint32 *)((vx_uint8 *)pDstImage + y * dstImageStrideInBytes);
-		vx_uint32 *pPrev = y ? (vx_uint32 *)((vx_uint8 *)pDstImage + (y - 1) * dstImageStrideInBytes) : nullptr;
-		__m128i carry = _mm_setzero_si128();
-		vx_uint32 rowSum = 0;
-		vx_uint32 x = 0;
-
-		// Process two 16-byte chunks per iteration so the loop is wider while
-		// each chunk still uses 128-bit intra-lane shifts for prefix sums.
-		for (; x + 32 <= dstWidth; x += 32)
-		{
-			__m128i bytesA = _mm_loadu_si128((__m128i *)(pSrc + x));
-			__m128i bytesB = _mm_loadu_si128((__m128i *)(pSrc + x + 16));
-
-			__m128i lo0 = _mm_cvtepu8_epi16(bytesA);
-			__m128i hi0 = _mm_unpackhi_epi8(bytesA, zeromask);
-			__m128i lo1 = _mm_cvtepu8_epi16(bytesB);
-			__m128i hi1 = _mm_unpackhi_epi8(bytesB, zeromask);
-
-			lo0 = _mm_add_epi16(lo0, _mm_slli_si128(lo0, 2));
-			lo0 = _mm_add_epi16(lo0, _mm_slli_si128(lo0, 4));
-			lo0 = _mm_add_epi16(lo0, _mm_slli_si128(lo0, 8));
-			hi0 = _mm_add_epi16(hi0, _mm_slli_si128(hi0, 2));
-			hi0 = _mm_add_epi16(hi0, _mm_slli_si128(hi0, 4));
-			hi0 = _mm_add_epi16(hi0, _mm_slli_si128(hi0, 8));
-			hi0 = _mm_add_epi16(hi0, _mm_shuffle_epi32(_mm_shufflehi_epi16(lo0, 0xff), 0xff));
-
-			lo1 = _mm_add_epi16(lo1, _mm_slli_si128(lo1, 2));
-			lo1 = _mm_add_epi16(lo1, _mm_slli_si128(lo1, 4));
-			lo1 = _mm_add_epi16(lo1, _mm_slli_si128(lo1, 8));
-			hi1 = _mm_add_epi16(hi1, _mm_slli_si128(hi1, 2));
-			hi1 = _mm_add_epi16(hi1, _mm_slli_si128(hi1, 4));
-			hi1 = _mm_add_epi16(hi1, _mm_slli_si128(hi1, 8));
-			hi1 = _mm_add_epi16(hi1, _mm_shuffle_epi32(_mm_shufflehi_epi16(lo1, 0xff), 0xff));
-
-			__m128i out0 = _mm_add_epi32(_mm_cvtepu16_epi32(lo0), carry);
-			__m128i out1 = _mm_add_epi32(_mm_unpackhi_epi16(lo0, zeromask), carry);
-			__m128i out2 = _mm_add_epi32(_mm_cvtepu16_epi32(hi0), carry);
-			__m128i out3 = _mm_add_epi32(_mm_unpackhi_epi16(hi0, zeromask), carry);
-
-			vx_uint32 firstChunkSum = (vx_uint32)_mm_extract_epi16(hi0, 7);
-			__m128i carry1 = _mm_add_epi32(carry, _mm_set1_epi32((int)firstChunkSum));
-
-			__m128i out4 = _mm_add_epi32(_mm_cvtepu16_epi32(lo1), carry1);
-			__m128i out5 = _mm_add_epi32(_mm_unpackhi_epi16(lo1, zeromask), carry1);
-			__m128i out6 = _mm_add_epi32(_mm_cvtepu16_epi32(hi1), carry1);
-			__m128i out7 = _mm_add_epi32(_mm_unpackhi_epi16(hi1, zeromask), carry1);
-
-			if (pPrev)
-			{
-				out0 = _mm_add_epi32(out0, _mm_loadu_si128((__m128i *)(pPrev + x)));
-				out1 = _mm_add_epi32(out1, _mm_loadu_si128((__m128i *)(pPrev + x + 4)));
-				out2 = _mm_add_epi32(out2, _mm_loadu_si128((__m128i *)(pPrev + x + 8)));
-				out3 = _mm_add_epi32(out3, _mm_loadu_si128((__m128i *)(pPrev + x + 12)));
-				out4 = _mm_add_epi32(out4, _mm_loadu_si128((__m128i *)(pPrev + x + 16)));
-				out5 = _mm_add_epi32(out5, _mm_loadu_si128((__m128i *)(pPrev + x + 20)));
-				out6 = _mm_add_epi32(out6, _mm_loadu_si128((__m128i *)(pPrev + x + 24)));
-				out7 = _mm_add_epi32(out7, _mm_loadu_si128((__m128i *)(pPrev + x + 28)));
-			}
-			_mm_storeu_si128((__m128i *)(pDst + x), out0);
-			_mm_storeu_si128((__m128i *)(pDst + x + 4), out1);
-			_mm_storeu_si128((__m128i *)(pDst + x + 8), out2);
-			_mm_storeu_si128((__m128i *)(pDst + x + 12), out3);
-			_mm_storeu_si128((__m128i *)(pDst + x + 16), out4);
-			_mm_storeu_si128((__m128i *)(pDst + x + 20), out5);
-			_mm_storeu_si128((__m128i *)(pDst + x + 24), out6);
-			_mm_storeu_si128((__m128i *)(pDst + x + 28), out7);
-
-			vx_uint32 secondChunkSum = (vx_uint32)_mm_extract_epi16(hi1, 7);
-			rowSum += firstChunkSum + secondChunkSum;
-			carry = _mm_set1_epi32((int)rowSum);
-		}
-
-		for (; x + 16 <= dstWidth; x += 16)
-		{
-			__m128i bytes = _mm_loadu_si128((__m128i *)(pSrc + x));
-			__m128i lo = _mm_cvtepu8_epi16(bytes);
-			__m128i hi = _mm_unpackhi_epi8(bytes, zeromask);
-
-			lo = _mm_add_epi16(lo, _mm_slli_si128(lo, 2));
-			lo = _mm_add_epi16(lo, _mm_slli_si128(lo, 4));
-			lo = _mm_add_epi16(lo, _mm_slli_si128(lo, 8));
-			hi = _mm_add_epi16(hi, _mm_slli_si128(hi, 2));
-			hi = _mm_add_epi16(hi, _mm_slli_si128(hi, 4));
-			hi = _mm_add_epi16(hi, _mm_slli_si128(hi, 8));
-			hi = _mm_add_epi16(hi, _mm_shuffle_epi32(_mm_shufflehi_epi16(lo, 0xff), 0xff));
-
-			__m128i out0 = _mm_add_epi32(_mm_cvtepu16_epi32(lo), carry);
-			__m128i out1 = _mm_add_epi32(_mm_unpackhi_epi16(lo, zeromask), carry);
-			__m128i out2 = _mm_add_epi32(_mm_cvtepu16_epi32(hi), carry);
-			__m128i out3 = _mm_add_epi32(_mm_unpackhi_epi16(hi, zeromask), carry);
-			if (pPrev)
-			{
-				out0 = _mm_add_epi32(out0, _mm_loadu_si128((__m128i *)(pPrev + x)));
-				out1 = _mm_add_epi32(out1, _mm_loadu_si128((__m128i *)(pPrev + x + 4)));
-				out2 = _mm_add_epi32(out2, _mm_loadu_si128((__m128i *)(pPrev + x + 8)));
-				out3 = _mm_add_epi32(out3, _mm_loadu_si128((__m128i *)(pPrev + x + 12)));
-			}
-			_mm_storeu_si128((__m128i *)(pDst + x), out0);
-			_mm_storeu_si128((__m128i *)(pDst + x + 4), out1);
-			_mm_storeu_si128((__m128i *)(pDst + x + 8), out2);
-			_mm_storeu_si128((__m128i *)(pDst + x + 12), out3);
-
-			rowSum += (vx_uint32)_mm_extract_epi16(hi, 7);
-			carry = _mm_set1_epi32((int)rowSum);
-		}
-
-		for (; x < dstWidth; x++)
-		{
-			rowSum += pSrc[x];
-			pDst[x] = rowSum + (pPrev ? pPrev[x] : 0);
-		}
+		pDst = (vx_uint32 *)((vx_uint8 *)pDstImage + y * dstImageStrideInBytes);
+		vx_uint32 *pPrev = (vx_uint32 *)((vx_uint8 *)pDstImage + (y - 1) * dstImageStrideInBytes);
+		HafCpu_IntegralImageRow_U32_U8<true>(dstWidth, pDst, pPrev, pSrc);
 	}
 	return AGO_SUCCESS;
 }
@@ -10384,6 +10402,12 @@ static inline __m256 HafCpu_FmaddAvx(__m256 a, __m256 b, __m256 c)
 	return _mm256_add_ps(_mm256_mul_ps(a, b), c);
 #endif
 }
+
+static inline __m256 HafCpu_RcpAvx(__m256 x)
+{
+	__m256 r = _mm256_rcp_ps(x);
+	return _mm256_mul_ps(r, _mm256_sub_ps(_mm256_set1_ps(2.0f), _mm256_mul_ps(x, r)));
+}
 #endif
 
 int HafCpu_Phase_U8_S16S16
@@ -10440,8 +10464,8 @@ int HafCpu_Phase_U8_S16S16
 			__m256 mnHi = _mm256_min_ps(axHi, ayHi);
 			__m256 mxHi = _mm256_max_ps(axHi, ayHi);
 
-			__m256 cLo = _mm256_div_ps(mnLo, _mm256_add_ps(mxLo, eps));
-			__m256 cHi = _mm256_div_ps(mnHi, _mm256_add_ps(mxHi, eps));
+			__m256 cLo = _mm256_mul_ps(mnLo, HafCpu_RcpAvx(_mm256_add_ps(mxLo, eps)));
+			__m256 cHi = _mm256_mul_ps(mnHi, HafCpu_RcpAvx(_mm256_add_ps(mxHi, eps)));
 			__m256 c2Lo = _mm256_mul_ps(cLo, cLo);
 			__m256 c2Hi = _mm256_mul_ps(cHi, cHi);
 
@@ -10477,7 +10501,7 @@ int HafCpu_Phase_U8_S16S16
 			__m256 useX = _mm256_cmp_ps(ay, ax, _CMP_LE_OQ);
 			__m256 mn = _mm256_min_ps(ax, ay);
 			__m256 mx = _mm256_max_ps(ax, ay);
-			__m256 c = _mm256_div_ps(mn, _mm256_add_ps(mx, eps));
+			__m256 c = _mm256_mul_ps(mn, HafCpu_RcpAvx(_mm256_add_ps(mx, eps)));
 			__m256 c2 = _mm256_mul_ps(c, c);
 			__m256 poly = _mm256_mul_ps(HafCpu_FmaddAvx(HafCpu_FmaddAvx(HafCpu_FmaddAvx(c2, p7, p5), c2, p3), c2, p1), c);
 			__m256 angle = _mm256_blendv_ps(_mm256_sub_ps(ninety, poly), poly, useX);

--- a/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp
@@ -10403,11 +10403,6 @@ static inline __m256 HafCpu_FmaddAvx(__m256 a, __m256 b, __m256 c)
 #endif
 }
 
-static inline __m256 HafCpu_RcpAvx(__m256 x)
-{
-	__m256 r = _mm256_rcp_ps(x);
-	return _mm256_mul_ps(r, _mm256_sub_ps(_mm256_set1_ps(2.0f), _mm256_mul_ps(x, r)));
-}
 #endif
 
 int HafCpu_Phase_U8_S16S16
@@ -10464,8 +10459,8 @@ int HafCpu_Phase_U8_S16S16
 			__m256 mnHi = _mm256_min_ps(axHi, ayHi);
 			__m256 mxHi = _mm256_max_ps(axHi, ayHi);
 
-			__m256 cLo = _mm256_mul_ps(mnLo, HafCpu_RcpAvx(_mm256_add_ps(mxLo, eps)));
-			__m256 cHi = _mm256_mul_ps(mnHi, HafCpu_RcpAvx(_mm256_add_ps(mxHi, eps)));
+			__m256 cLo = _mm256_div_ps(mnLo, _mm256_add_ps(mxLo, eps));
+			__m256 cHi = _mm256_div_ps(mnHi, _mm256_add_ps(mxHi, eps));
 			__m256 c2Lo = _mm256_mul_ps(cLo, cLo);
 			__m256 c2Hi = _mm256_mul_ps(cHi, cHi);
 
@@ -10501,7 +10496,7 @@ int HafCpu_Phase_U8_S16S16
 			__m256 useX = _mm256_cmp_ps(ay, ax, _CMP_LE_OQ);
 			__m256 mn = _mm256_min_ps(ax, ay);
 			__m256 mx = _mm256_max_ps(ax, ay);
-			__m256 c = _mm256_mul_ps(mn, HafCpu_RcpAvx(_mm256_add_ps(mx, eps)));
+			__m256 c = _mm256_div_ps(mn, _mm256_add_ps(mx, eps));
 			__m256 c2 = _mm256_mul_ps(c, c);
 			__m256 poly = _mm256_mul_ps(HafCpu_FmaddAvx(HafCpu_FmaddAvx(HafCpu_FmaddAvx(c2, p7, p5), c2, p3), c2, p1), c);
 			__m256 angle = _mm256_blendv_ps(_mm256_sub_ps(ninety, poly), poly, useX);

--- a/amd_openvx/openvx/ago/ago_haf_cpu_fast_corners.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_fast_corners.cpp
@@ -474,6 +474,7 @@ int HafCpu_FastCorners_XY_U8_NoSupression
 		generateOffset(srcStride, neighbor_offset);
 
 	pSrcImage += (srcStride * 3) + 3;													// Leave first three rows and start from the third pixel
+	const __m128i thresh = _mm_set1_epi16(t);
 
 	for (int height = 0; height < innerHeight; height++)
 	{
@@ -483,7 +484,6 @@ int HafCpu_FastCorners_XY_U8_NoSupression
 		for (int x = 0; x < (alignedWidth >> 3); x++)
 		{
 			__m128i rowMinus3, rowMinus2, rowMinus1, row, rowPlus1, rowPlus2, rowPlus3;
-			__m128i thresh = _mm_set1_epi16(t);
 
 			// Load all 7 rows in their final form for the boundary shuffles below
 			// (same byte offsets the dataFastCornersPixelMaskAll table expects).
@@ -638,15 +638,16 @@ int HafCpu_FastCorners_XY_U8_Supression
 	if (postfixWidth)
 		generateOffset(srcStride, neighbor_offset);
 
-	memset(pScratch, 0, sizeof(vx_uint8) * srcWidth * srcHeight);
-
 	if ((innerWidth == 0) || (innerHeight == 0))
 	{
 		*pDstCornerCount = 0;
 		return AGO_SUCCESS;
 	}
 
+	memset(pScratch, 0, sizeof(vx_uint8) * srcWidth * srcHeight);
+
 	pSrcImage += (srcStride * 3) + 3;														// Leave first three rows and start from the third pixel
+	const __m128i thresh = _mm_set1_epi16(t);
 
 	for (int height = 0; height < innerHeight; height++)
 	{
@@ -656,7 +657,6 @@ int HafCpu_FastCorners_XY_U8_Supression
 		for (int x = 0; x < (alignedWidth >> 3); x++)
 		{
 			__m128i rowMinus3, rowMinus2, rowMinus1, row, rowPlus1, rowPlus2, rowPlus3;
-			__m128i thresh = _mm_set1_epi16(t);
 
 			// Load all 7 rows in their final form for boundary shuffles.
 			rowMinus3 = _mm_loadu_si128((__m128i *)(pLocalSrc - 3 * srcStride - 1));

--- a/amd_openvx/openvx/ago/ago_haf_cpu_filter.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_filter.cpp
@@ -3033,11 +3033,9 @@ int HafCpu_Convolve_S16_U8_3xN
 	__m128i result0, result1, result2, result3, row, mul, temp0, temp1;
 	__m128i zeromask = _mm_setzero_si128();
 
-	int prefixWidth = intptr_t(pDstImage) & 15;
-	prefixWidth = (prefixWidth == 0) ? 0 : (16 - prefixWidth);
-	prefixWidth >>= 1;														// 2 bytes = 1 pixel
-	int postfixWidth = ((int)dstWidth - prefixWidth) & 15;					// 16 pixels processed at a time in SSE loop
-	int alignedWidth = (int)dstWidth - prefixWidth - postfixWidth;
+	int prefixWidth = 0;
+	int postfixWidth = (int)dstWidth & 15;					// 16 pixels processed at a time in SSE loop
+	int alignedWidth = (int)dstWidth - postfixWidth;
 
 	int height = (int)dstHeight;
 	int srcStride = (int)srcImageStrideInBytes;
@@ -3174,8 +3172,8 @@ int HafCpu_Convolve_S16_U8_3xN
 
 			row = _mm_packs_epi32(result2, result3);
 			temp0 = _mm_packs_epi32(result0, result1);
-			_mm_store_si128(pLocalDst_xmm++, temp0);
-			_mm_store_si128(pLocalDst_xmm++, row);
+			_mm_storeu_si128(pLocalDst_xmm++, temp0);
+			_mm_storeu_si128(pLocalDst_xmm++, row);
 
 			pLocalSrc += 16;
 			width--;
@@ -3226,10 +3224,9 @@ int HafCpu_Convolve_U8_U8_3xN
 	__m128i result0, result1, result2, result3, row, mul, temp0, temp1;
 	__m128i zeromask = _mm_setzero_si128();
 
-	int prefixWidth = intptr_t(pDstImage) & 15;
-	prefixWidth = (prefixWidth == 0) ? 0 : (16 - prefixWidth);
-	int postfixWidth = ((int)dstWidth - prefixWidth) & 15;					// 16 pixels processed at a time in SSE loop
-	int alignedWidth = (int)dstWidth - prefixWidth - postfixWidth;
+	int prefixWidth = 0;
+	int postfixWidth = (int)dstWidth & 15;					// 16 pixels processed at a time in SSE loop
+	int alignedWidth = (int)dstWidth - postfixWidth;
 
 	int height = (int)dstHeight;
 	int srcStride = (int)srcImageStrideInBytes;
@@ -3424,7 +3421,7 @@ int HafCpu_Convolve_U8_U8_3xN
 			row = _mm_packs_epi32(result2, result3);
 			temp0 = _mm_packs_epi32(result0, result1);
 			row = _mm_packus_epi16(temp0, row);
-			_mm_store_si128(pLocalDst_xmm++, row);
+			_mm_storeu_si128(pLocalDst_xmm++, row);
 
 			pLocalSrc += 16;
 			width--;

--- a/amd_openvx/openvx/ago/ago_haf_cpu_pyramid.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_cpu_pyramid.cpp
@@ -112,10 +112,9 @@ int HafCpu_ScaleGaussianHalf_U8_U8_5x5
 	unsigned short * r3 = (unsigned short *)(pScratch + 3 * alignedDstStride);
 	unsigned short * r4 = (unsigned short *)(pScratch + 4 * alignedDstStride);
 
-	int prefixWidth = intptr_t(pDstImage) & 15;
-	prefixWidth = (prefixWidth == 0) ? 0 : (16 - prefixWidth);
-	int postfixWidth = ((int)dstWidth - prefixWidth) & 15;
-	int alignedWidth = (int)dstWidth - prefixWidth - postfixWidth;
+	int prefixWidth = 0;
+	int postfixWidth = (int)dstWidth & 15;
+	int alignedWidth = (int)dstWidth - postfixWidth;
 	int srcRowOffset = sampleFirstRow ? 0 : srcImageStrideInBytes;
 	int srcColOffset = sampleFirstColumn ? 0 : 1;
 
@@ -244,7 +243,7 @@ int HafCpu_ScaleGaussianHalf_U8_U8_5x5
 			pixels_plus1L = _mm_srli_epi16(pixels_plus1L, 8);											// Divide by 256
 
 			pixels_plus1L = _mm_packus_epi16(pixels_plus1L, pixels_plus1H);
-			_mm_store_si128((__m128i *)pLocalDst, pixels_plus1L);
+			_mm_storeu_si128((__m128i *)pLocalDst, pixels_plus1L);
 
 			pLocalSrc += 32;
 			pLocalSrc_NextRow += 32;


### PR DESCRIPTION
## Motivation

Implemented the CPU kernel parity

## Technical Details

* amd_openvx/openvx/ago/ago_haf_cpu_arithmetic.cpp: sped up AVX phase by replacing div_ps with Newton-refined reciprocal; split integral-image row handling to remove hot-loop previous-row branching.
* amd_openvx/openvx/ago/ago_haf_cpu_pyramid.cpp: removed scalar alignment prefix in the 5x5 half-scale Gaussian path and switched output stores to unaligned SIMD stores.
* amd_openvx/openvx/ago/ago_haf_cpu_filter.cpp: removed scalar alignment prefix for 3xN convolve hot paths and switched stores to unaligned SIMD stores.
* amd_openvx/openvx/ago/ago_haf_cpu_fast_corners.cpp: hoisted threshold vector setup out of inner loops and avoided scratch clearing on empty inputs.

## Test Plan

GitHub workflow - conformance and performance checks

## Test Result

CI Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
