### PR TITLE
Fix HIP CannyEdgeDetector failure on repeated vxProcessGraph

### DIFF
--- a/amd_openvx/openvx/ago/ago_util_hip.cpp
+++ b/amd_openvx/openvx/ago/ago_util_hip.cpp
@@ -667,6 +667,10 @@ static int agoGpuHipDataOutputAtomicSync(AgoGraph * graph, AgoData * data) {
         }
         int64_t etime = agoGetClockCounter();
         graph->gpu_perf.buffer_read += etime - stime;
+        // clamp stackTop to capacity to prevent reading past the GPU buffer
+        if (stack > data->u.cannystack.count) {
+            stack = data->u.cannystack.count;
+        }
         data->u.cannystack.stackTop = stack;
         if (data->u.cannystack.stackTop > 0) {
             if (data->hip_memory) {
@@ -678,6 +682,19 @@ static int agoGpuHipDataOutputAtomicSync(AgoGraph * graph, AgoData * data) {
             }
             int64_t etime = agoGetClockCounter();
             graph->gpu_perf.buffer_read += etime - stime;
+        }
+        // reset the GPU counter to 0 so the next graph execution starts from a clean stack
+        // (matches the OpenCL path in agoGpuOclDataOutputAtomicSync)
+        if (data->hip_memory) {
+            vx_uint32 zero = 0;
+            stime = agoGetClockCounter();
+            hipError_t err = hipMemcpyHtoD(data->hip_memory, (void *)&zero, sizeof(vx_uint32));
+            if (err) {
+                agoAddLogEntry(&data->ref, VX_FAILURE, "ERROR: hipMemcpyHtoD() for stacktop reset => %d\n", err);
+                return -1;
+            }
+            etime = agoGetClockCounter();
+            graph->gpu_perf.buffer_write += etime - stime;
         }
     }
     return 0;


### PR DESCRIPTION
## Problem

On the HIP backend, calling `vxProcessGraph` more than once on a graph that contains a `CannyEdgeDetector` node eventually fails with errors such as `invalid argument` or `single node wait failed` from the Harris-Sobel/Canny stack kernels.

The root cause is that the HIP Canny stack output synchronization reads the GPU atomic counter in `agoGpuHipDataOutputAtomicSync()` but never resets it to zero. On the next graph execution the Canny kernel sees the previous `stackTop`, writes past the allocated stack buffer, and corrupts the following nodes.

The OpenCL backend already resets the counter after reading via map/unmap in `agoGpuOclDataOutputAtomicSync()`; the HIP path was missing the equivalent reset.

## Fix

In `amd_openvx/openvx/ago/ago_util_hip.cpp`:

1. Clamp `stackTop` to the Canny-stack capacity as a defensive guard.
2. After reading the stack contents, write zero back to the GPU atomic counter with `hipMemcpyHtoD()` so the next `vxProcessGraph` starts from a clean stack.

This matches the OpenCL implementation and fixes the repeated-execution failure.

Fixes: ROCm/MIVisionX#1693

## Testing

Built the HIP backend on an AMD RYZEN AI MAX+ PRO 395 / Radeon 8060S APU with:

```bash
cmake -DBACKEND=HIP -DGPU_SUPPORT=ON -DNEURAL_NET=OFF -DLOOM=OFF -DMIGRAPHX=OFF ..
make -j$(nproc)
```

Ran the full Khronos OpenVX 1.3 conformance suite (`OpenVX-cts`) from the `test_data` directory with the HIP libraries on `LD_LIBRARY_PATH`:

```
[ ALL DONE ] 5820 test(s) from 69 test case(s) ran
[ PASSED   ] 5820 test(s)
[ FAILED   ] 0 test(s)
[ DISABLED ] 8190 test(s)

Baseline:  863 required / 863 passed / 0 failed → PASSED
Vision:   4957 required / 4957 passed / 0 failed → PASSED
```

Also ran `openvx-mark --vision-parity` at FHD; the overall vision score is ~45,510 MP/s, on par with the pre-fix baseline (~45,782 MP/s), so there is no performance regression. `CannyEdgeDetector` runs at ~560 MP/s / ~3.7 ms at FHD.

## Impact

- Corrects Canny behavior on repeated graph execution for HIP.
- No change to OpenCL, CPU, or non-Canny code paths.
- No performance degradation observed.
