### PR TITLE
Enable HIP GPU target for HarrisCorners

### DIFF
--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -1907,7 +1907,7 @@ int ovxKernel_HarrisCorners(AgoNode * node, AgoKernelCommand cmd)
     else if (cmd == ago_kernel_cmd_query_target_support) {
         node->target_support_flags = AGO_KERNEL_FLAG_SUBGRAPH
                     | AGO_KERNEL_FLAG_DEVICE_CPU
-#if ENABLE_OPENCL
+#if ENABLE_OPENCL || ENABLE_HIP
                     | AGO_KERNEL_FLAG_DEVICE_GPU
 #endif
                     ;


### PR DESCRIPTION
## Problem

`ovxKernel_HarrisCorners` in `amd_openvx/openvx/ago/ago_kernel_api.cpp` advertised `AGO_KERNEL_FLAG_DEVICE_GPU` only when `ENABLE_OPENCL` was defined. On HIP builds the HarrisCorners subgraph was therefore not eligible for GPU scheduling and fell back to the CPU path.

On the test APU (AMD RYZEN AI MAX+ PRO 395 / Radeon 8060S) this produced two symptoms:

1. Conformance runs intermittently hit an `invalid argument` / `single node wait failed` error from the CPU fallback path because the outer graph expected GPU scheduling for the Harris subgraph.
2. `openvx-mark` reported HarrisCorners at ~21 MP/s on HIP with high variance, compared with the CPU implementation at ~155 MP/s.

## Fix

Extend the preprocessor guard that sets `AGO_KERNEL_FLAG_DEVICE_GPU` to also include `ENABLE_HIP`, so HIP builds can schedule the HarrisCorners subgraph on the GPU just like OpenCL builds:

```cpp
#if ENABLE_OPENCL || ENABLE_HIP
                    | AGO_KERNEL_FLAG_DEVICE_GPU
#endif
```

This is a minimal, targeted change that makes HIP behavior consistent with OpenCL for this kernel.

## Testing

Built the HIP backend on the same APU with:

```bash
cmake -DBACKEND=HIP -DGPU_SUPPORT=ON -DNEURAL_NET=OFF -DLOOM=OFF -DMIGRAPHX=OFF ..
make -j$(nproc)
```

Ran the full Khronos OpenVX 1.3 conformance suite from the `test_data` directory with the HIP libraries on `LD_LIBRARY_PATH`:

```
[ ALL DONE ] 5820 test(s) from 69 test case(s) ran
[ PASSED   ] 5820 test(s)
[ FAILED   ] 0 test(s)
[ DISABLED ] 8190 test(s)

Baseline:  863 required / 863 passed / 0 failed → PASSED
Vision:   4957 required / 4957 passed / 0 failed → PASSED
```

Ran `openvx-mark --vision-parity` at FHD against the HIP backend:

- Overall vision score: ~45,510 MP/s (consistent with the pre-fix HIP baseline of ~45,782 MP/s).
- HarrisCorners now completes successfully on the GPU path.
- No regressions in any other kernel.

## Notes / follow-up

This change enables GPU scheduling for HarrisCorners on HIP. The Harris GPU kernels themselves are functional and conformant, but absolute throughput on this integrated APU is still lower than the CPU implementation. Further kernel-level optimization (launch configuration, occupancy, algorithmic tuning) is outside the scope of this scheduling fix and can be addressed in a follow-up PR if needed.
