### PR TITLE
CTS - Issue fix

### DIFF
--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -1891,6 +1891,16 @@ int ovxKernel_HarrisCorners(AgoNode * node, AgoKernelCommand cmd)
         node->metaList[6].data.u.arr.capacity = 0;
         node->metaList[7].data.u.scalar.type = VX_TYPE_SIZE;
         status = VX_SUCCESS;
+        // On HIP the HarrisCorners merge stage is CPU-only. Running the
+        // preceding Sobel/Score kernels on the GPU and then reading the score
+        // image back to the CPU for merge/sort is much slower than running the
+        // whole subgraph on the CPU on integrated APUs. Force CPU affinity for
+        // the HarrisCorners subgraph on HIP so all child nodes (Sobel, Score,
+        // NMS, merge) are scheduled on the CPU. Ago will propagate this
+        // affinity to the child nodes created during drama division.
+#if ENABLE_HIP
+        node->attr_affinity.device_type = AGO_KERNEL_FLAG_DEVICE_CPU;
+#endif
         //disable buffer merging for HarrisCorners on both OCL and HIP GPU backends temporarily as a workaround
 #if ENABLE_OPENCL || ENABLE_HIP
     char textBuffer[1024];

--- a/amd_openvx/openvx/ago/ago_util_hip.cpp
+++ b/amd_openvx/openvx/ago/ago_util_hip.cpp
@@ -667,6 +667,10 @@ static int agoGpuHipDataOutputAtomicSync(AgoGraph * graph, AgoData * data) {
         }
         int64_t etime = agoGetClockCounter();
         graph->gpu_perf.buffer_read += etime - stime;
+        // clamp stackTop to capacity to prevent reading past the GPU buffer
+        if (stack > data->u.cannystack.count) {
+            stack = data->u.cannystack.count;
+        }
         data->u.cannystack.stackTop = stack;
         if (data->u.cannystack.stackTop > 0) {
             if (data->hip_memory) {
@@ -678,6 +682,19 @@ static int agoGpuHipDataOutputAtomicSync(AgoGraph * graph, AgoData * data) {
             }
             int64_t etime = agoGetClockCounter();
             graph->gpu_perf.buffer_read += etime - stime;
+        }
+        // reset the GPU counter to 0 so the next graph execution starts from a clean stack
+        // (matches the OpenCL path in agoGpuOclDataOutputAtomicSync)
+        if (data->hip_memory) {
+            vx_uint32 zero = 0;
+            stime = agoGetClockCounter();
+            hipError_t err = hipMemcpyHtoD(data->hip_memory, (void *)&zero, sizeof(vx_uint32));
+            if (err) {
+                agoAddLogEntry(&data->ref, VX_FAILURE, "ERROR: hipMemcpyHtoD() for stacktop reset => %d\n", err);
+                return -1;
+            }
+            etime = agoGetClockCounter();
+            graph->gpu_perf.buffer_write += etime - stime;
         }
     }
     return 0;


### PR DESCRIPTION
## Motivation

Fix tot develop failures

## Technical Details

* Current implementation did not reset the HIP Canny stack GPU counter after readback, so repeated vxProcessGraph can reuse stale stackTop. Fix issue - #1693

*  HarrisCorners HIP CPU-affinity override - leaving the mixed GPU/CPU Harris path vulnerable to expensive readback.

## Test Plan

GitHub workflow and MathCI Tests - CTS and performance

## Test Result

All stages should pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
