### PR TITLE
OpenVX - fix rocm 7.14 LLVM failure

### DIFF
--- a/amd_openvx/openvx/CMakeLists.txt
+++ b/amd_openvx/openvx/CMakeLists.txt
@@ -171,7 +171,11 @@ else()
     # -mavx2   -- Support AVX2 256-bit SIMD operations for arithmetic and filter kernels.
     # -mfma    -- Support FMA3 fused multiply-add for polynomial-heavy kernels (e.g. phase/atan2).
     # -mbmi2   -- Support BMI2 bit manipulation instructions for U1 image format operations.
-    target_compile_options(openvx PRIVATE -msse4.2 -mavx2 -mfma -mbmi2)
+    # -fno-vectorize -- Disable LLVM's loop auto-vectorizer. The ago_haf_cpu_*.cpp kernels are
+    #   already hand-vectorized with AVX2/SSE intrinsics; ROCm 7.14's amdclang++ (LLVM 23)
+    #   miscompiles these loops at -O3 by re-vectorizing them with a corrupt induction variable,
+    #   causing out-of-bounds accesses and segfaults (e.g. HafCpu_ChannelCopy_U8_U8).
+    target_compile_options(openvx PRIVATE -msse4.2 -mavx2 -mfma -mbmi2 -fno-vectorize)
     target_compile_definitions(openvx PRIVATE USE_AVX=1)
     target_compile_definitions(openvx PRIVATE USE_FMA=1)
     target_compile_definitions(openvx PRIVATE USE_BMI2=1)

--- a/amd_openvx/openvx/CMakeLists.txt
+++ b/amd_openvx/openvx/CMakeLists.txt
@@ -175,7 +175,10 @@ else()
     #   already hand-vectorized with AVX2/SSE intrinsics; ROCm 7.14's amdclang++ (LLVM 23)
     #   miscompiles these loops at -O3 by re-vectorizing them with a corrupt induction variable,
     #   causing out-of-bounds accesses and segfaults (e.g. HafCpu_ChannelCopy_U8_U8).
-    target_compile_options(openvx PRIVATE -msse4.2 -mavx2 -mfma -mbmi2 -fno-vectorize)
+    target_compile_options(openvx PRIVATE -msse4.2 -mavx2 -mfma -mbmi2)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(openvx PRIVATE -fno-vectorize)
+    endif()
     target_compile_definitions(openvx PRIVATE USE_AVX=1)
     target_compile_definitions(openvx PRIVATE USE_FMA=1)
     target_compile_definitions(openvx PRIVATE USE_BMI2=1)


### PR DESCRIPTION
## Motivation

Issue #1707 

JIRA - ROCM-27291

## Technical Details
Full details - #1707 
* -O3 miscompiles the hand-vectorized CPU kernels
* -O3 -fno-vectorize - to disable O3 vector unroll

## Test Plan

GitHub workflow and mathCI

## Test Result

All ci stages should pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
