### PR TITLE
[CMakeLists.txt] update gfx115x(gfx1150,gfx1152 & gfx1153) GPU architecture support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ if("${BACKEND}" STREQUAL "HIP")
     else() # if we don't have rocm_check_target_ids, keep optional targets out of the default list
       set(OPTIONAL_GPU_TARGETS_AVAILABLE "")
     endif()
-    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1151;gfx1102;gfx950;gfx1200;gfx1201;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1150;gfx1151;gfx1152;gfx1153;gfx1102;gfx950;gfx1200;gfx1201;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
   endif()
 
   # Set AMD GPU_TARGETS


### PR DESCRIPTION
## Motivation

[MIVisionX] Enable AMD Strix Point(gfx1150), Krackan Point(gfx1152) and Krackan2(gfx1153) architecture support.

## Technical Details

Add gfx1150, gfx1152 and gfx1153 to the DEFAULT_GPU_TARGETS list in CMakeLists.txt to enable MIVisionX library builds for these AMD RDNA3.5 GPU architectures.

Changes:
CMakeLists.txt: Added gfx1150 to DEFAULT_GPU_TARGETS between gfx1101 and gfx1151
CMakeLists.txt: Added gfx1152 and gfx1153 entries to
DEFAULT_GPU_TARGETS between gfx1151 and gfx1102
Background:
The gfx1150, gfx1152 and gfx1153 are part of the RDNA3.5 GPU family.
Adding these targets ensures that MIVisionX can be compiled
with native support for these GPUs without requiring users to
manually specify GPU_TARGETS.

Since gfx115x represents the same IP level, include all known variants
to ensure consistent support across the family.

## Test Plan

All ctests must pass

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
