### PR TITLE
OpenVX 1.3.2 — CTS update compatibility and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The full documentation for MIVisionX is available at [https://rocm.docs.amd.com/
 * `MIVISIONX_HIP_CU_COUNT` environment variable to limit the number of compute units used by HIP kernels at runtime
 
 ### Fixed
-* CTS MinMaxLoc count-scalar type: `ovxKernel_MinMaxLoc` and all `agoKernel_MinMaxLoc_*` sub-kernels now declare and write count outputs as `VX_TYPE_SIZE` instead of `VX_TYPE_UINT32`, matching the OpenVX 1.3.2 spec and Khronos CTS
+* MinMaxLoc count-scalar type: `ovxKernel_MinMaxLoc` and all `agoKernel_MinMaxLoc_*` sub-kernels now declare and write count outputs as `VX_TYPE_SIZE` instead of `VX_TYPE_UINT32`, matching the OpenVX 1.3.2 spec and Khronos CTS
+* Updated `tests/openvx_api_tests/vxu_api/vxu_api.cpp` and all 17 MinMaxLoc GDF files in `tests/amd_openvx_gdfs/cpu/` to use `VX_TYPE_SIZE` / `scalar:SIZE` for count scalars
 
 ### Changed
 * README and sub-library documentation updated to explicitly state OpenVX **1.3.2** conformance throughout; spec links updated to the 1.3.2 URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 The full documentation for MIVisionX is available at [https://rocm.docs.amd.com/projects/MIVisionX/en/latest/doxygen/html/index.html](https://rocm.docs.amd.com/projects/MIVisionX/en/latest/doxygen/html/index.html)
 
+## Unreleased
+
+### Added
+* OpenVX 1.3.2 full Vision Conformance Feature Set — `vxQueryImage` now supports `VX_IMAGE_IS_UNIFORM` and `VX_IMAGE_UNIFORM_VALUE`; `vxMinMaxLoc` count scalars changed to `VX_TYPE_SIZE` per spec
+* HIP GPU architecture support for gfx115x (Radeon RX 9000 / gfx1150, gfx1151, gfx1152, gfx1153)
+* `MIVISIONX_HIP_CU_COUNT` environment variable to limit the number of compute units used by HIP kernels at runtime
+
+### Fixed
+* CTS MinMaxLoc count-scalar type: `ovxKernel_MinMaxLoc` and all `agoKernel_MinMaxLoc_*` sub-kernels now declare and write count outputs as `VX_TYPE_SIZE` instead of `VX_TYPE_UINT32`, matching the OpenVX 1.3.2 spec and Khronos CTS
+
+### Changed
+* README and sub-library documentation updated to explicitly state OpenVX **1.3.2** conformance throughout; spec links updated to the 1.3.2 URL
+
 ## MIVisionX 4.0.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center"><img width="70%" src="https://raw.githubusercontent.com/ROCm/MIVisionX/develop/docs/data/MIVisionX.png" /></p>
 
-AMD MIVisionX is a computer vision toolkit built around a highly optimized, conformant open-source implementation of the <a href="https://www.khronos.org/openvx/" target="_blank">Khronos OpenVX&trade; 1.3</a> specification. As of the `4.0.0` release, MIVisionX ships three components: the [AMD OpenVX&trade;](amd_openvx/README.md) engine, the [AMD RPP](amd_openvx_extensions/amd_rpp/README.md) OpenVX extension, and the [RunVX](utilities/runvx/README.md#amd-runvx) graph executor — across `CPU`, `HIP`, and `OpenCL` backends.
+AMD MIVisionX is a computer vision toolkit built around a highly optimized, conformant open-source implementation of the <a href="https://registry.khronos.org/OpenVX/specs/1.3.2/html/OpenVX_Specification_1_3_2.html" target="_blank">Khronos OpenVX&trade; 1.3.2</a> specification. As of the `4.0.0` release, MIVisionX ships three components: the [AMD OpenVX&trade;](amd_openvx/README.md) engine, the [AMD RPP](amd_openvx_extensions/amd_rpp/README.md) OpenVX extension, and the [RunVX](utilities/runvx/README.md#amd-runvx) graph executor — across `CPU`, `HIP`, and `OpenCL` backends.
 
 ## AMD OpenVX&trade; Extensions
 

--- a/amd_openvx/openvx/README.md
+++ b/amd_openvx/openvx/README.md
@@ -1,6 +1,6 @@
 # AMD OpenVX&trade; Library
 
-AMD OpenVX&trade; library is a highly optimized open-source implementation of the [Khronos OpenVX 1.3](https://registry.khronos.org/OpenVX/specs/1.3/html/OpenVX_Specification_1_3.html) computer vision specification. This directory contains the core library source code.
+AMD OpenVX&trade; library is a highly optimized open-source implementation of the [Khronos OpenVX 1.3.2](https://registry.khronos.org/OpenVX/specs/1.3.2/html/OpenVX_Specification_1_3_2.html) computer vision specification. This directory contains the core library source code.
 
 ## Libraries
 

--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -1349,8 +1349,8 @@ int ovxKernel_MinMaxLoc(AgoNode * node, AgoKernelCommand cmd)
         node->metaList[3].data.u.arr.capacity = 0;
         node->metaList[4].data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         node->metaList[4].data.u.arr.capacity = 0;
-        node->metaList[5].data.u.scalar.type = VX_TYPE_UINT32;
-        node->metaList[6].data.u.scalar.type = VX_TYPE_UINT32;
+        node->metaList[5].data.u.scalar.type = VX_TYPE_SIZE;
+        node->metaList[6].data.u.scalar.type = VX_TYPE_SIZE;
         status = VX_SUCCESS;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
@@ -21353,7 +21353,7 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min(AgoNode * node, AgoKernel
         // set output info
         vx_meta_format meta;
         meta = &node->metaList[0];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21400,7 +21400,7 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Max(AgoNode * node, AgoKernel
         // set output info
         vx_meta_format meta;
         meta = &node->metaList[0];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21447,9 +21447,9 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_None_Count_MinMax(AgoNode * node, AgoKer
         // set output info
         vx_meta_format meta;
         meta = &node->metaList[0];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
         meta = &node->metaList[1];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21490,7 +21490,7 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Min_Count_Min(AgoNode * node, AgoKernelC
         }
         else {
             iMinLoc->u.arr.numitems = min(minCount, (vx_uint32)iMinLoc->u.arr.capacity);
-            if (iMinCount) iMinCount->u.scalar.u.u = minCount;
+            if (iMinCount) iMinCount->u.scalar.u.s = minCount;
         }
     }
     else if (cmd == ago_kernel_cmd_validate) {
@@ -21506,7 +21506,7 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Min_Count_Min(AgoNode * node, AgoKernelC
         meta = &node->metaList[0];
         meta->data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         meta = &node->metaList[1];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21548,8 +21548,8 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Min_Count_MinMax(AgoNode * node, AgoKern
         }
         else {
             iMinLoc->u.arr.numitems = min(minCount, (vx_uint32)iMinLoc->u.arr.capacity);
-            if (iMinCount) iMinCount->u.scalar.u.u = minCount;
-            if (iMaxCount) iMaxCount->u.scalar.u.u = maxCount;
+            if (iMinCount) iMinCount->u.scalar.u.s = minCount;
+            if (iMaxCount) iMaxCount->u.scalar.u.s = maxCount;
         }
     }
     else if (cmd == ago_kernel_cmd_validate) {
@@ -21565,9 +21565,9 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Min_Count_MinMax(AgoNode * node, AgoKern
         meta = &node->metaList[0];
         meta->data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         meta = &node->metaList[1];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
         meta = &node->metaList[2];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21608,7 +21608,7 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Max_Count_Max(AgoNode * node, AgoKernelC
         }
         else {
             iMaxLoc->u.arr.numitems = min(maxCount, (vx_uint32)iMaxLoc->u.arr.capacity);
-            if (iMaxCount) iMaxCount->u.scalar.u.u = maxCount;
+            if (iMaxCount) iMaxCount->u.scalar.u.s = maxCount;
         }
     }
     else if (cmd == ago_kernel_cmd_validate) {
@@ -21624,7 +21624,7 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Max_Count_Max(AgoNode * node, AgoKernelC
         meta = &node->metaList[0];
         meta->data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         meta = &node->metaList[1];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21666,8 +21666,8 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Max_Count_MinMax(AgoNode * node, AgoKern
         }
         else {
             iMaxLoc->u.arr.numitems = min(maxCount, (vx_uint32)iMaxLoc->u.arr.capacity);
-            if (iMaxCount) iMaxCount->u.scalar.u.u = maxCount;
-            if (iMinCount) iMinCount->u.scalar.u.u = minCount;
+            if (iMaxCount) iMaxCount->u.scalar.u.s = maxCount;
+            if (iMinCount) iMinCount->u.scalar.u.s = minCount;
         }
     }
     else if (cmd == ago_kernel_cmd_validate) {
@@ -21683,9 +21683,9 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Max_Count_MinMax(AgoNode * node, AgoKern
         meta = &node->metaList[0];
         meta->data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         meta = &node->metaList[1];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
         meta = &node->metaList[2];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21730,8 +21730,8 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_MinMax_Count_MinMax(AgoNode * node, AgoK
         else {
             iMinLoc->u.arr.numitems = min(minCount, (vx_uint32)iMinLoc->u.arr.capacity);
             iMaxLoc->u.arr.numitems = min(maxCount, (vx_uint32)iMaxLoc->u.arr.capacity);
-            if (iMinCount) iMinCount->u.scalar.u.u = minCount;
-            if (iMaxCount) iMaxCount->u.scalar.u.u = maxCount;
+            if (iMinCount) iMinCount->u.scalar.u.s = minCount;
+            if (iMaxCount) iMaxCount->u.scalar.u.s = maxCount;
         }
     }
     else if (cmd == ago_kernel_cmd_validate) {
@@ -21749,9 +21749,9 @@ int agoKernel_MinMaxLoc_DATA_U8DATA_Loc_MinMax_Count_MinMax(AgoNode * node, AgoK
         meta = &node->metaList[1];
         meta->data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         meta = &node->metaList[2];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
         meta = &node->metaList[3];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21798,7 +21798,7 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_None_Count_Min(AgoNode * node, AgoKerne
         // set output info
         vx_meta_format meta;
         meta = &node->metaList[0];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21845,7 +21845,7 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_None_Count_Max(AgoNode * node, AgoKerne
         // set output info
         vx_meta_format meta;
         meta = &node->metaList[0];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21892,9 +21892,9 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_None_Count_MinMax(AgoNode * node, AgoKe
         // set output info
         vx_meta_format meta;
         meta = &node->metaList[0];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
         meta = &node->metaList[1];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21935,7 +21935,7 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_Min_Count_Min(AgoNode * node, AgoKernel
         }
         else {
             iMinLoc->u.arr.numitems = min(minCount, (vx_uint32)iMinLoc->u.arr.capacity);
-            if (iMinCount) iMinCount->u.scalar.u.u = minCount;
+            if (iMinCount) iMinCount->u.scalar.u.s = minCount;
         }
     }
     else if (cmd == ago_kernel_cmd_validate) {
@@ -21951,7 +21951,7 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_Min_Count_Min(AgoNode * node, AgoKernel
         meta = &node->metaList[0];
         meta->data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         meta = &node->metaList[1];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -21993,8 +21993,8 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_Min_Count_MinMax(AgoNode * node, AgoKer
         }
         else {
             iMinLoc->u.arr.numitems = min(minCount, (vx_uint32)iMinLoc->u.arr.capacity);
-            if (iMinCount) iMinCount->u.scalar.u.u = minCount;
-            if (iMaxCount) iMaxCount->u.scalar.u.u = maxCount;
+            if (iMinCount) iMinCount->u.scalar.u.s = minCount;
+            if (iMaxCount) iMaxCount->u.scalar.u.s = maxCount;
         }
     }
     else if (cmd == ago_kernel_cmd_validate) {
@@ -22010,9 +22010,9 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_Min_Count_MinMax(AgoNode * node, AgoKer
         meta = &node->metaList[0];
         meta->data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         meta = &node->metaList[1];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
         meta = &node->metaList[2];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -22053,7 +22053,7 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_Max_Count_Max(AgoNode * node, AgoKernel
         }
         else {
             iMaxLoc->u.arr.numitems = min(maxCount, (vx_uint32)iMaxLoc->u.arr.capacity);
-            if (iMaxCount) iMaxCount->u.scalar.u.u = maxCount;
+            if (iMaxCount) iMaxCount->u.scalar.u.s = maxCount;
         }
     }
     else if (cmd == ago_kernel_cmd_validate) {
@@ -22069,7 +22069,7 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_Max_Count_Max(AgoNode * node, AgoKernel
         meta = &node->metaList[0];
         meta->data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         meta = &node->metaList[1];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -22111,8 +22111,8 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_Max_Count_MinMax(AgoNode * node, AgoKer
         }
         else {
             iMaxLoc->u.arr.numitems = min(maxCount, (vx_uint32)iMaxLoc->u.arr.capacity);
-            if (iMinCount) iMinCount->u.scalar.u.u = minCount;
-            if (iMaxCount) iMaxCount->u.scalar.u.u = maxCount;
+            if (iMinCount) iMinCount->u.scalar.u.s = minCount;
+            if (iMaxCount) iMaxCount->u.scalar.u.s = maxCount;
         }
     }
     else if (cmd == ago_kernel_cmd_validate) {
@@ -22128,9 +22128,9 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_Max_Count_MinMax(AgoNode * node, AgoKer
         meta = &node->metaList[0];
         meta->data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         meta = &node->metaList[1];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
         meta = &node->metaList[2];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;
@@ -22175,8 +22175,8 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_MinMax_Count_MinMax(AgoNode * node, Ago
         else {
             iMinLoc->u.arr.numitems = min(minCount, (vx_uint32)iMinLoc->u.arr.capacity);
             iMaxLoc->u.arr.numitems = min(maxCount, (vx_uint32)iMaxLoc->u.arr.capacity);
-            if (iMinCount) iMinCount->u.scalar.u.u = minCount;
-            if (iMaxCount) iMaxCount->u.scalar.u.u = maxCount;
+            if (iMinCount) iMinCount->u.scalar.u.s = minCount;
+            if (iMaxCount) iMaxCount->u.scalar.u.s = maxCount;
         }
     }
     else if (cmd == ago_kernel_cmd_validate) {
@@ -22194,9 +22194,9 @@ int agoKernel_MinMaxLoc_DATA_S16DATA_Loc_MinMax_Count_MinMax(AgoNode * node, Ago
         meta = &node->metaList[1];
         meta->data.u.arr.itemtype = VX_TYPE_COORDINATES2D;
         meta = &node->metaList[2];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
         meta = &node->metaList[3];
-        meta->data.u.scalar.type = VX_TYPE_UINT32;
+        meta->data.u.scalar.type = VX_TYPE_SIZE;
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_Max_Count_Max.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_Max_Count_Max.gdf
@@ -5,6 +5,6 @@ data output_minval = scalar:INT16,0
 data output_maxval = scalar:INT16,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval NULL output_maxloc NULL output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_Max_Count_MinMax.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_Max_Count_MinMax.gdf
@@ -5,6 +5,6 @@ data output_minval = scalar:INT16,0
 data output_maxval = scalar:INT16,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval NULL output_maxloc output_mincount output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_Min_Count_Min.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_Min_Count_Min.gdf
@@ -1,6 +1,6 @@
 # agoKernel_MinMaxLoc_DATA_S16DATA_Loc_None_Count_Min
 #data input = image:480,360,U008
-#data output_maxcount = scalar:UINT32,0
+#data output_maxcount = scalar:SIZE,0
 #node com.amd.openvx.MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min output_maxcount input
 
 data inter_luma = image:1280,720,S016
@@ -8,6 +8,6 @@ data output_minval = scalar:INT16,0
 data output_maxval = scalar:INT16,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval output_minloc NULL output_mincount NULL

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_Min_Count_MinMax.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_Min_Count_MinMax.gdf
@@ -1,6 +1,6 @@
 # agoKernel_MinMaxLoc_DATA_S16DATA_Loc_None_Count_Min
 #data input = image:480,360,U008
-#data output_maxcount = scalar:UINT32,0
+#data output_maxcount = scalar:SIZE,0
 #node com.amd.openvx.MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min output_maxcount input
 
 data inter_luma = image:1280,720,S016
@@ -8,6 +8,6 @@ data output_minval = scalar:INT16,0
 data output_maxval = scalar:INT16,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval output_minloc NULL output_mincount output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_None_Count_Max.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_None_Count_Max.gdf
@@ -5,6 +5,6 @@ data output_minval = scalar:INT16,0
 data output_maxval = scalar:INT16,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval NULL NULL NULL output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_None_Count_Min.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_None_Count_Min.gdf
@@ -1,6 +1,6 @@
 # agoKernel_MinMaxLoc_DATA_S16DATA_Loc_None_Count_Min
 #data input = image:480,360,U008
-#data output_maxcount = scalar:UINT32,0
+#data output_maxcount = scalar:SIZE,0
 #node com.amd.openvx.MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min output_maxcount input
 
 data inter_luma = image:1280,720,S016
@@ -8,6 +8,6 @@ data output_minval = scalar:INT16,0
 data output_maxval = scalar:INT16,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval NULL NULL output_mincount NULL

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_None_Count_MinMax.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_S16DATA_Loc_None_Count_MinMax.gdf
@@ -5,6 +5,6 @@ data output_minval = scalar:INT16,0
 data output_maxval = scalar:INT16,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval NULL NULL output_mincount output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_Max_Count_Max.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_Max_Count_Max.gdf
@@ -1,6 +1,6 @@
 # agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Max_Count_Max
 #data input = image:480,360,U008
-#data output_maxcount = scalar:UINT32,0
+#data output_maxcount = scalar:SIZE,0
 #node com.amd.openvx.MinMaxLoc_DATA_U8DATA_Loc_Max_Count_Max output_maxcount input
 
 data inter_luma = image:1280,720,U008
@@ -8,7 +8,7 @@ data output_minval = scalar:UINT8,0
 data output_maxval = scalar:UINT8,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval null output_maxloc null output_maxcount
 #node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval output_minloc output_maxloc output_mincount output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_Max_Count_MinMax.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_Max_Count_MinMax.gdf
@@ -1,6 +1,6 @@
 # agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Max_Count_MinMax
 #data input = image:480,360,U008
-#data output_maxcount = scalar:UINT32,0
+#data output_maxcount = scalar:SIZE,0
 #node com.amd.openvx.MinMaxLoc_DATA_U8DATA_Loc_Min_Count_MinMax output_maxcount input
 
 data inter_luma = image:1280,720,U008
@@ -8,7 +8,7 @@ data output_minval = scalar:UINT8,0
 data output_maxval = scalar:UINT8,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval null output_maxloc output_mincount output_maxcount
 #node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval output_minloc output_maxloc output_mincount output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_Min_Count_MinMax.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_Min_Count_MinMax.gdf
@@ -1,6 +1,6 @@
 # agoKernel_MinMaxLoc_DATA_U8DATA_Loc_Min_Count_MinMax
 #data input = image:480,360,U008
-#data output_maxcount = scalar:UINT32,0
+#data output_maxcount = scalar:SIZE,0
 #node com.amd.openvx.MinMaxLoc_DATA_U8DATA_Loc_Min_Count_MinMax output_maxcount input
 
 data inter_luma = image:1280,720,U008
@@ -8,7 +8,7 @@ data output_minval = scalar:UINT8,0
 data output_maxval = scalar:UINT8,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval output_minloc NULL output_mincount output_maxcount
 #node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval output_minloc output_maxloc output_mincount output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_None_Count_Max.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_None_Count_Max.gdf
@@ -1,6 +1,6 @@
 # agoKernel_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Max
 #data input = image:480,360,U008
-#data output_maxcount = scalar:UINT32,0
+#data output_maxcount = scalar:SIZE,0
 #node com.amd.openvx.MinMaxLoc_DATA_U8DATA_Loc_None_Count_Max output_maxcount input
 
 data inter_luma = image:1280,720,U008
@@ -8,6 +8,6 @@ data output_minval = scalar:UINT8,0
 data output_maxval = scalar:UINT8,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval NULL NULL NULL output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min.gdf
@@ -1,6 +1,6 @@
 # agoKernel_MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min
 #data input = image:480,360,U008
-#data output_maxcount = scalar:UINT32,0
+#data output_maxcount = scalar:SIZE,0
 #node com.amd.openvx.MinMaxLoc_DATA_U8DATA_Loc_None_Count_Min output_maxcount input
 
 data inter_luma = image:1280,720,U008
@@ -8,6 +8,6 @@ data output_minval = scalar:UINT8,0
 data output_maxval = scalar:UINT8,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval NULL NULL output_mincount NULL

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_None_Count_MinMax.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_DATA_U8DATA_Loc_None_Count_MinMax.gdf
@@ -2,6 +2,6 @@
 data inter_luma = uniform-image:1280,720,U008,125
 data output_minval = scalar:UINT8,0
 data output_maxval = scalar:UINT8,0
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval NULL NULL output_mincount output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_S16_Loc_Max_Count_MinMax.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_S16_Loc_Max_Count_MinMax.gdf
@@ -3,6 +3,6 @@ data input = image:1280,720,S016
 data output_minval = scalar:INT16,0
 data output_maxval = scalar:INT16,0
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc input output_minval output_maxval NULL output_maxloc output_mincount output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_S16_Loc_MinMax_Count_MinMax.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_S16_Loc_MinMax_Count_MinMax.gdf
@@ -4,6 +4,6 @@ data output_minval = scalar:INT16,0
 data output_maxval = scalar:INT16,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc input output_minval output_maxval output_minloc output_maxloc output_mincount output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_U8_Loc_MinMax_Count_MinMax.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_U8_Loc_MinMax_Count_MinMax.gdf
@@ -4,6 +4,6 @@ data output_minval = scalar:UINT8,0
 data output_maxval = scalar:UINT8,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc input output_minval output_maxval output_minloc output_maxloc output_mincount output_maxcount

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_U8_Loc_Min_Count_Min.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_U8_Loc_Min_Count_Min.gdf
@@ -3,5 +3,5 @@ data input = image:1280,720,U008
 data output_minval = scalar:UINT8,0
 data output_maxval = scalar:UINT8,0
 data output_minloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc input output_minval output_maxval output_minloc NULL output_mincount NULL

--- a/tests/amd_openvx_gdfs/cpu/MinMaxLoc_U8_Loc_None_Count_MinMax.gdf
+++ b/tests/amd_openvx_gdfs/cpu/MinMaxLoc_U8_Loc_None_Count_MinMax.gdf
@@ -4,6 +4,6 @@ data minval = scalar:UINT8,0
 data maxval = scalar:UINT8,0
 data minloc = array:VX_TYPE_COORDINATES2D,1000
 data maxloc = array:VX_TYPE_COORDINATES2D,1000
-data mincount = scalar:UINT32,0
-data maxcount = scalar:UINT32,0
+data mincount = scalar:SIZE,0
+data maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc input_1 minval maxval minloc maxloc mincount maxcount

--- a/tests/amd_openvx_gdfs/runOpenVX.py
+++ b/tests/amd_openvx_gdfs/runOpenVX.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2020 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/amd_openvx_gdfs/vision_profile/26_minMaxLoc.gdf
+++ b/tests/amd_openvx_gdfs/vision_profile/26_minMaxLoc.gdf
@@ -6,6 +6,6 @@ data output_minval = scalar:UINT8,0
 data output_maxval = scalar:UINT8,0
 data output_minloc = array:COORDINATES2D,1000
 data output_maxloc = array:COORDINATES2D,1000
-data output_mincount = scalar:UINT32,0
-data output_maxcount = scalar:UINT32,0
+data output_mincount = scalar:SIZE,0
+data output_maxcount = scalar:SIZE,0
 node org.khronos.openvx.minmaxloc inter_luma output_minval output_maxval output_minloc output_maxloc output_mincount output_maxcount

--- a/tests/openvx_api_tests/vxu_api/vxu_api.cpp
+++ b/tests/openvx_api_tests/vxu_api/vxu_api.cpp
@@ -709,8 +709,8 @@ static int test_vxuMinMaxLoc(vx_context context) {
     vx_scalar maxVal = vxCreateScalar(context, VX_TYPE_UINT8, NULL);
     vx_array  minLoc = vxCreateArray(context, VX_TYPE_COORDINATES2D, 1);
     vx_array  maxLoc = vxCreateArray(context, VX_TYPE_COORDINATES2D, 1);
-    vx_scalar minCount = vxCreateScalar(context, VX_TYPE_UINT32, NULL);
-    vx_scalar maxCount = vxCreateScalar(context, VX_TYPE_UINT32, NULL);
+    vx_scalar minCount = vxCreateScalar(context, VX_TYPE_SIZE, NULL);
+    vx_scalar maxCount = vxCreateScalar(context, VX_TYPE_SIZE, NULL);
     CHECK_NULL(src, "src");
 
     CHECK_STATUS(vxuMinMaxLoc(context, src, minVal, maxVal, minLoc, maxLoc, minCount, maxCount));

--- a/tests/openvx_conformance_tests/runConformanceTests.py
+++ b/tests/openvx_conformance_tests/runConformanceTests.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-"""Build and run OpenVX 1.3 Conformance Tests (CTS) for AMD MIVisionX.
+"""Build and run OpenVX 1.3.2 Conformance Tests (CTS) for AMD MIVisionX.
 
 This script automates:
   1. Building MIVisionX for one or more backends (HOST / OCL / HIP).
@@ -51,9 +51,9 @@ import sys
 # ---------------------------------------------------------------------------
 
 __author__ = "Kiriti Nagesh Gowda"
-__copyright__ = "Copyright 2018 - 2024, AMD MIVisionX - Conformance System Report"
+__copyright__ = "Copyright 2018 - 2026, AMD MIVisionX - Conformance System Report"
 __license__ = "MIT"
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __maintainer__ = "Kiriti Nagesh Gowda"
 __email__ = "mivisionx.support@amd.com"
 __status__ = "Shipping"
@@ -302,7 +302,7 @@ def write_system_report(
             f.write(f"* OpenVX {key} Library\n")
             write_formatted(out, f)
         f.write("\n")
-        f.write(f"\n\n---\n**Copyright AMD ROCm MIVisionX 2018 - 2024 -- runConformanceTests.py V-{__version__}**\n")
+        f.write(f"\n\n---\n**Copyright AMD ROCm MIVisionX 2018 - 2026 -- runConformanceTests.py V-{__version__}**\n")
 
 
 # ---------------------------------------------------------------------------
@@ -359,7 +359,7 @@ def configure_and_build_cts(
             "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
             f"-DOPENVX_INCLUDES={openvx_include}",
             openvx_libs_arg,
-            # The OpenVX 1.3 CTS hardcodes -O3 for C sources. GCC 13 on WSL can
+            # The OpenVX 1.3.2 CTS hardcodes -O3 for C sources. GCC 13 on WSL can
             # miscompile test_array.c's small-type verifier at that level even
             # when the implementation returns the correct array bytes.
             "-DOPENVX_CFLAGS=-O0",

--- a/tests/vision_tests/runVisionTests.py
+++ b/tests/vision_tests/runVisionTests.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2020 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,7 @@ import sys
 import platform
 
 __author__ = "Kiriti Nagesh Gowda"
-__copyright__ = "Copyright 2018 - 2024, AMD MIVisionX - Vision Test Full Report"
+__copyright__ = "Copyright 2018 - 2026, AMD MIVisionX - Vision Test Full Report"
 __license__ = "MIT"
 __version__ = "1.4.0"
 __maintainer__ = "Kiriti Nagesh Gowda"


### PR DESCRIPTION
## Motivation

The [Khronos OpenVX-cts `openvx_1.3.2` branch](https://github.com/KhronosGroup/OpenVX-cts) moved forward (commit `4a6f667`, PR #42 "Default options"), changing the `vxMinMaxLoc` count-scalar type from `VX_TYPE_UINT32` to `VX_TYPE_SIZE` and adding a stale-output re-run test for `LaplacianPyramid`. This PR fixes MIVisionX to pass the updated CTS and brings all version strings and documentation in line with OpenVX **1.3.2**.

## Technical Details

### Bug fix — `vxMinMaxLoc` count scalars (`ago_kernel_api.cpp`)

The Khronos CTS now creates `minCount` and `maxCount` output scalars as `VX_TYPE_SIZE` (matching the OpenVX 1.3.2 spec). MIVisionX was declaring and writing them as `VX_TYPE_UINT32`, causing `vxVerifyGraph` to return `VX_ERROR_INVALID_TYPE` for all four `MinMaxLoc.OnRandom` test cases.

Fixed in two places:

- **`ovxKernel_MinMaxLoc` (validate)** — `metaList[5]` and `metaList[6]` type changed from `VX_TYPE_UINT32` to `VX_TYPE_SIZE`.
- **All 12 `agoKernel_MinMaxLoc_*` sub-kernels (validate + execute)** — validate meta type changed to `VX_TYPE_SIZE`; execute writes changed from `u.scalar.u.u` to `u.scalar.u.s` (correct union member for `vx_size` on 64-bit).

**Result:** `MinMaxLoc.OnRandom/{0,1,2,3}` (Immediate and Graph mode, U8 and S16) all pass on HOST, HIP-CPU, and HIP-GPU.

## Test Plan

Both `conformance.yml` and `conformance-hip.yml` already clone `--depth 1 -b openvx_1.3.2`, which is a floating branch — they automatically pick up the latest CTS on every run. No filter updates were needed; the new `LaplacianPyramid` re-run test and the updated `MinMaxLoc` test are covered by the existing `vision-pyramid` and `vision-statistics` CI jobs respectively.

## Test Result

| Backend | Vision profile (4958 required) | Notes |
|---------|-------------------------------|-------|
| HOST — CPU | **4958 / 4958 PASS** | CI-style filtered run |
| HIP — CPU target | **4958 / 4958 PASS** | CI-style filtered run |
| HIP — GPU target | **4958 / 4958 PASS** | CI-style filtered run |

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
