### PR TITLE
OpenVX: ROCTX/rocprof tracing enhancements

### DIFF
--- a/.github/scripts/run_rocprof_gdf.py
+++ b/.github/scripts/run_rocprof_gdf.py
@@ -531,9 +531,9 @@ def build_summary(
         )
         lines.append("")
 
+    lines.append("## Aggregate memory copies (host <-> device)")
+    lines.append("")
     if aggregate_copies:
-        lines.append("## Aggregate memory copies (host <-> device)")
-        lines.append("")
         lines.append("| Direction | Count | Total bytes | Total time |")
         lines.append("|-----------|------:|------------:|-----------:|")
         for direction, stat in sorted(
@@ -543,11 +543,20 @@ def build_summary(
                 f"| `{direction}` | {stat.count} | {_format_bytes(stat.total_bytes)} "
                 f"| {_format_us(stat.total_us)} |"
             )
-        lines.append("")
+    elif backend == "CPU":
+        lines.append(
+            "_N/A for the CPU backend — host-to-device copies only occur on GPU runs._"
+        )
+    else:
+        lines.append(
+            "_No memory-copy data captured. Verify that the HIP backend transferred "
+            "buffers and that rocprofv3 collected the memory-copy trace._"
+        )
+    lines.append("")
 
+    lines.append("## Aggregate memory allocations (hipMalloc/hipFree)")
+    lines.append("")
     if aggregate_allocs:
-        lines.append("## Aggregate memory allocations (hipMalloc/hipFree)")
-        lines.append("")
         lines.append("| Operation | Count | Total bytes |")
         lines.append("|-----------|------:|------------:|")
         for operation, stat in sorted(
@@ -556,7 +565,16 @@ def build_summary(
             lines.append(
                 f"| `{operation}` | {stat.count} | {_format_bytes(stat.total_bytes)} |"
             )
-        lines.append("")
+    elif backend == "CPU":
+        lines.append(
+            "_N/A for the CPU backend — device allocations only occur on GPU runs._"
+        )
+    else:
+        lines.append(
+            "_No memory-allocation data captured. Verify that the HIP backend "
+            "allocated device memory and that rocprofv3 collected the trace._"
+        )
+    lines.append("")
 
     lines.append("## Artifacts")
     lines.append("")

--- a/.github/workflows/rocprof-gdf.yml
+++ b/.github/workflows/rocprof-gdf.yml
@@ -21,16 +21,19 @@
 name: ROCprof GDF profiling
 
 on:
+  # Post-merge: only when tracing-relevant files change.
   push:
     branches: [master, main, develop]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
+    paths:
+      - 'amd_openvx/openvx/ago/**'
+      - 'amd_openvx/openvx/CMakeLists.txt'
+      - '.github/scripts/run_rocprof_gdf.py'
+      - '.github/workflows/rocprof-gdf.yml'
+  # PRs trigger for every event (so the label can start a run); the `gate`
+  # job below decides whether the GPU jobs actually run.
   pull_request:
     branches: [master, main, develop]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
+    types: [opened, synchronize, reopened, labeled]
 
 defaults:
   run:
@@ -45,6 +48,54 @@ concurrency:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # Gate — decides whether the expensive GPU jobs run. This keeps the GPU
+  # runner pool free on unrelated PRs. It runs on a cheap GitHub-hosted runner.
+  # Runs when ANY of:
+  #   * the event is a push (already path-filtered above), or
+  #   * the PR carries the 'run-rocprof' label, or
+  #   * the PR changed a tracing-relevant file.
+  # ---------------------------------------------------------------------------
+
+  gate:
+    name: Decide whether to profile
+    runs-on: ubuntu-24.04
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-rocprof') }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            echo "push event -> run"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "run-rocprof label present -> run"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # PR without the label: run only if a tracing-relevant file changed.
+          changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || true)"
+          echo "changed files:"; echo "$changed"
+          if echo "$changed" | grep -qE '^(amd_openvx/openvx/ago/|amd_openvx/openvx/CMakeLists\.txt|\.github/scripts/run_rocprof_gdf\.py|\.github/workflows/rocprof-gdf\.yml)'; then
+            echo "tracing-relevant change -> run"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no tracing-relevant change and no label -> skip"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ---------------------------------------------------------------------------
   # Build Stage — two parallel builds on the ROCm container.
   # CPU is built inside the ROCm container because MIVISIONX_ENABLE_ROCPROF=ON
   # still requires the roctx header/library from /opt/rocm.
@@ -52,6 +103,8 @@ jobs:
 
   build-rocprof-cpu:
     name: Build MIVisionX (CPU + ROCTX)
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on:
       group: linux-shark39-runner-group
     container:
@@ -90,6 +143,8 @@ jobs:
 
   build-rocprof-hip:
     name: Build MIVisionX (HIP + ROCTX)
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on:
       group: linux-shark39-runner-group
     container:

--- a/amd_openvx/README.md
+++ b/amd_openvx/README.md
@@ -61,4 +61,57 @@ On Windows, the default backend is `OpenCL`; pass `-DGPU_SUPPORT=OFF` for a CPU-
 > [!NOTE]
 > AMD GPU HIP backend is not supported on Windows.
 
+## Profiling with rocprof / ROCTX
+
+AMD OpenVX can emit [ROCTX](https://rocm.docs.amd.com/projects/roctracer/en/latest/) markers so graph execution can be correlated with GPU kernel activity in [`rocprofv3`](https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html) traces. This is useful for understanding per-node GPU time, host&harr;device transfers, and the effect of `MIVISIONX_HIP_CU_COUNT`.
+
+The instrumentation is **off by default** and adds no dependency unless explicitly enabled.
+
+### Enable at build time
+
+```shell
+# From the MIVisionX repo root
+cmake -B build -S . -DMIVISIONX_ENABLE_ROCPROF=ON
+cmake --build build -j$(nproc)
+```
+
+When `MIVISIONX_ENABLE_ROCPROF=ON`, CMake links `libroctx64` from `${ROCM_PATH}`. If the library is not found the build still succeeds with tracing compiled out (a warning is printed).
+
+### Enable at run time
+
+Even when compiled in, no markers are emitted unless `MIVISIONX_ROCPROF` is set to `1`/`true`/`yes` (honored on both Linux and Windows):
+
+```shell
+export MIVISIONX_ROCPROF=1
+export LD_LIBRARY_PATH=$ROCM_PATH/lib:$LD_LIBRARY_PATH
+rocprofv3 --marker-trace --kernel-trace --memory-copy-trace --memory-allocation-trace \
+    --output-format csv pftrace --output-directory ./trace \
+    -- runvx -frames:10 -affinity:GPU graph.gdf
+```
+
+### What you get in the trace
+
+| Range / event | Meaning |
+|---------------|---------|
+| `MIVisionX: agoExecuteGraph` | one full graph execution |
+| `MIVisionX: pipelined execution` | one pipelined/streaming graph iteration (wraps `agoExecuteGraph`) |
+| `MIVisionX: level N` | all nodes at hierarchical level N |
+| `<kernel name>` (e.g. `com.amd.openvx.ColorConvert_RGB_RGBX`) | a single node's launch/execute |
+| `MIVisionX: copy-in <kernel> paramN` | host&rarr;device transfer of an input, attributed to the node/param that needed it |
+| `MIVisionX: copy-out <kernel>` | device&rarr;host transfer of a node's output |
+| `MIVisionX: GPU sync/wait` | where the graph blocks on GPU completion (`hipStreamSynchronize`/`clFinish`) &mdash; the real GPU kernel time lands here, since per-node ranges only cover the asynchronous launch |
+| kernel dispatches, memory copies, allocations | captured by `rocprofv3` directly (`--kernel-trace`, `--memory-copy-trace`, `--memory-allocation-trace`) |
+
+> [!NOTE]
+> GPU kernel launches are asynchronous. The per-node ranges (`<kernel name>`) measure the time to **enqueue** the kernel, not to run it. Actual device execution is bounded by the `MIVisionX: GPU sync/wait` range and shown precisely by the kernel-dispatch trace.
+
+Open the resulting `*.pftrace` at [ui.perfetto.dev](https://ui.perfetto.dev) to see the ROCTX ranges, kernel dispatches, and memory transfers on a single timeline.
+
+### Continuous integration
+
+The `ROCprof GDF profiling` workflow (`.github/workflows/rocprof-gdf.yml`) builds with `MIVISIONX_ENABLE_ROCPROF=ON` and profiles a small set of GDFs under `rocprofv3`. Because it uses GPU runners, it is gated so it does not run on unrelated pull requests:
+
+* **Push** to `master`/`main`/`develop` &mdash; runs only when a tracing-relevant file changes (`amd_openvx/openvx/ago/**`, `amd_openvx/openvx/CMakeLists.txt`, the profiling script, or the workflow).
+* **Pull request** &mdash; runs automatically when one of those files changes, or on demand for any PR by adding the **`run-rocprof`** label.
+
 OpenVX and the OpenVX logo are trademarks of the Khronos Group Inc.

--- a/amd_openvx/openvx/ago/ago_interface.cpp
+++ b/amd_openvx/openvx/ago/ago_interface.cpp
@@ -2022,6 +2022,9 @@ static int agoDataSyncFromGpuToCpu(AgoGraph * graph, AgoNode * node, AgoData * d
     if (dataToSync->opencl_buffer && !(dataToSync->buffer_sync_flags & AGO_BUFFER_SYNC_FLAG_DIRTY_SYNCHED)) {
         if (node->flags & AGO_KERNEL_FLAG_DEVICE_GPU) {
             if (dataToSync->buffer_sync_flags & (AGO_BUFFER_SYNC_FLAG_DIRTY_BY_NODE | AGO_BUFFER_SYNC_FLAG_DIRTY_BY_COMMIT)) {
+                // Copy-out (device->host) of this node's output, attributed to the node.
+                AGO_ROCTX_RANGE_FMT("MIVisionX: copy-out %s",
+                         (node->akernel && node->akernel->name[0] != '\0') ? node->akernel->name : "unknown");
                 int64_t stime = agoGetClockCounter();
                 vx_size size = dataToSync->size;
                 if (dataToSync->ref.type == VX_TYPE_LUT) {
@@ -2145,6 +2148,9 @@ static int agoDataSyncFromGpuToCpu(AgoGraph * graph, AgoNode * node, AgoData * d
     if (dataToSync->hip_memory && !(dataToSync->buffer_sync_flags & AGO_BUFFER_SYNC_FLAG_DIRTY_SYNCHED)) {
         if (node->flags & AGO_KERNEL_FLAG_DEVICE_GPU) {
             if (dataToSync->buffer_sync_flags & (AGO_BUFFER_SYNC_FLAG_DIRTY_BY_NODE | AGO_BUFFER_SYNC_FLAG_DIRTY_BY_COMMIT)) {
+                // Copy-out (device->host) of this node's output, attributed to the node.
+                AGO_ROCTX_RANGE_FMT("MIVisionX: copy-out %s",
+                         (node->akernel && node->akernel->name[0] != '\0') ? node->akernel->name : "unknown");
                 int64_t stime = agoGetClockCounter();
                 vx_size size = dataToSync->size;
                 if (dataToSync->ref.type == VX_TYPE_LUT) {
@@ -2347,6 +2353,11 @@ int agoExecuteGraph(AgoGraph * graph)
                         if (dataToSync->buffer_sync_flags & (AGO_BUFFER_SYNC_FLAG_DIRTY_BY_NODE | AGO_BUFFER_SYNC_FLAG_DIRTY_BY_COMMIT) &&
                             dataToSync->opencl_buffer && !(dataToSync->buffer_sync_flags & AGO_BUFFER_SYNC_FLAG_DIRTY_SYNCHED))
                         {
+                            // Copy-in (host->device) for this input. Attributing it to
+                            // node+param lets a developer see which input drove a costly
+                            // transfer, rather than an anonymous copy in the memory trace.
+                            AGO_ROCTX_RANGE_FMT("MIVisionX: copy-in %s param%u",
+                                     (node->akernel && node->akernel->name[0] != '\0') ? node->akernel->name : "unknown", i);
                             status = agoDirective((vx_reference)dataToSync, VX_DIRECTIVE_AMD_COPY_TO_OPENCL);
                             if(status != VX_SUCCESS) {
                                 agoAddLogEntry((vx_reference)graph, VX_FAILURE, "ERROR: agoDirective(*,VX_DIRECTIVE_AMD_COPY_TO_OPENCL) failed (%d:%s)\n", status, agoEnum2Name(status));
@@ -2400,6 +2411,11 @@ int agoExecuteGraph(AgoGraph * graph)
                         if (dataToSync->buffer_sync_flags & (AGO_BUFFER_SYNC_FLAG_DIRTY_BY_NODE | AGO_BUFFER_SYNC_FLAG_DIRTY_BY_COMMIT) &&
                             dataToSync->hip_memory && !(dataToSync->buffer_sync_flags & AGO_BUFFER_SYNC_FLAG_DIRTY_SYNCHED))
                         {
+                            // Copy-in (host->device) for this input. Attributing it to
+                            // node+param lets a developer see which input drove a costly
+                            // transfer, rather than an anonymous copy in the memory trace.
+                            AGO_ROCTX_RANGE_FMT("MIVisionX: copy-in %s param%u",
+                                     (node->akernel && node->akernel->name[0] != '\0') ? node->akernel->name : "unknown", i);
                             status = agoDirective((vx_reference)dataToSync, VX_DIRECTIVE_AMD_COPY_TO_HIPMEM);
                             if(status != VX_SUCCESS) {
                                 agoAddLogEntry((vx_reference)graph, VX_FAILURE, "ERROR: agoDirective(*,VX_DIRECTIVE_AMD_COPY_TO_HIPMEM) failed (%d:%s)\n", status, agoEnum2Name(status));
@@ -2586,6 +2602,12 @@ int agoExecuteGraph(AgoGraph * graph)
         }
     }
 #if (ENABLE_OPENCL||ENABLE_HIP)
+    {
+    // Per-node GPU ranges above only cover the asynchronous launch; the device
+    // does the real work here. This range bounds the actual GPU completion
+    // (stream sync / node wait), so the trace shows where kernel time lands.
+    // RAII range (not push/pop) because the wait paths below return early.
+    AGO_ROCTX_RANGE("MIVisionX: GPU sync/wait");
     agoPerfProfileEntry(graph, ago_profile_type_wait_begin, &graph->ref);
     if (nodeLaunchHierarchicalLevel > 0) {
         status = agoWaitForNodesCompletion(graph);
@@ -2615,6 +2637,7 @@ int agoExecuteGraph(AgoGraph * graph)
             agoNotifyNodeCompleted(graph, node);
     }
     agoPerfProfileEntry(graph, ago_profile_type_wait_end, &graph->ref);
+    }
     graph->gpu_perf_total.kernel_enqueue += graph->gpu_perf.kernel_enqueue;
     graph->gpu_perf_total.kernel_wait += graph->gpu_perf.kernel_wait;
     graph->gpu_perf_total.buffer_read += graph->gpu_perf.buffer_read;

--- a/amd_openvx/openvx/ago/ago_pipelining.cpp
+++ b/amd_openvx/openvx/ago/ago_pipelining.cpp
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #include "ago_internal.h"
+#include "ago_roctx.h"
 #include <chrono>
 
 //
@@ -528,6 +529,11 @@ int agoExecutePipelinedGraphOnce(AgoGraph * graph)
     AgoGraphPipeliningState * pipe = graph->pipelining;
     if (!pipe)
         return VX_FAILURE;
+
+    // One range per pipelined execution (manual/auto/streaming all funnel here);
+    // the agoExecuteGraph range nests inside it so the trace shows each pipeline
+    // iteration and its per-node work together.
+    AGO_ROCTX_RANGE("MIVisionX: pipelined execution");
 
     // Collect default data references bound to each graph parameter.
     std::vector<AgoParamBinding> bindings = agoCollectGraphParameterBindings(graph);

--- a/amd_openvx/openvx/ago/ago_roctx.h
+++ b/amd_openvx/openvx/ago/ago_roctx.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2015 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -30,24 +30,26 @@ THE SOFTWARE.
 
 #if defined(MIVISIONX_ENABLE_ROCPROF)
 
+#include "ago_platform.h"
 #include <roctracer/roctx.h>
-#include <atomic>
 #include <cstdio>
-#include <cstdlib>
 
 namespace AgoRocTx {
-    // Runtime guard: read MIVISIONX_ROCPROF once per process.
-    // 0 = uninitialized, 1 = enabled, 2 = disabled.
-    inline int getEnabledState() {
-        static std::atomic<int> state{0};
-        int s = state.load(std::memory_order_relaxed);
-        if (s != 0) return s;
-        const char* env = std::getenv("MIVISIONX_ROCPROF");
-        s = (env && (env[0] == '1' || env[0] == 't' || env[0] == 'T' || env[0] == 'y' || env[0] == 'Y')) ? 1 : 2;
-        state.store(s, std::memory_order_relaxed);
-        return s;
+    // Runtime guard: read MIVISIONX_ROCPROF once per process. The function-local
+    // static is initialized exactly once with C++11-guaranteed cross-thread
+    // ordering, so no explicit atomics are needed. agoGetEnvironmentVariable is
+    // used instead of std::getenv so the flag is honored on Windows, where the
+    // CRT and Win32 keep separate environment blocks.
+    inline bool enabled() {
+        static const bool value = []() {
+            char buf[16] = {0};
+            if (!agoGetEnvironmentVariable("MIVISIONX_ROCPROF", buf, sizeof(buf)))
+                return false;
+            const char c = buf[0];
+            return c == '1' || c == 't' || c == 'T' || c == 'y' || c == 'Y';
+        }();
+        return value;
     }
-    inline bool enabled() { return getEnabledState() == 1; }
 
     // Lightweight RAII scope guard for a range.
     // Usage: AgoRocTx::Range range("my range");


### PR DESCRIPTION
## Summary

Follow-up to #1739. Makes the ROCTX/rocprof tracing feature more meaningful for developers and closes gaps found in the initial implementation. All changes are opt-in behind `MIVISIONX_ENABLE_ROCPROF` (build) + `MIVISIONX_ROCPROF` (runtime); default builds are unaffected.

## Instrumentation gaps closed

- **GPU kernel time is now visible.** Per-node ranges only cover the asynchronous launch. Added a `MIVisionX: GPU sync/wait` range around the graph-completion `hipStreamSynchronize`/`clFinish`, where real device time lands.
- **Memory copies attributed to nodes.** Added `MIVisionX: copy-in <kernel> paramN` (H2D) on both the OpenCL and HIP input-sync paths, and `MIVisionX: copy-out <kernel>` (D2H) in both `agoDataSyncFromGpuToCpu` variants — so a developer can see which node/param drove a transfer instead of an anonymous copy event.
- **Pipelining/streaming instrumented.** Added `MIVisionX: pipelined execution` in `agoExecutePipelinedGraphOnce` (the common funnel for manual/auto/streaming), nesting the existing `agoExecuteGraph` range.

## Correctness / portability

- **Windows env var honored.** `enabled()` now reads `MIVISIONX_ROCPROF` via `agoGetEnvironmentVariable()` (GetEnvironmentVariableA on Windows) instead of `std::getenv`, which misses variables set through the Win32 API.
- **Thread-safe init.** Replaced the relaxed-atomic double-check in the runtime guard with a C++11 magic-static — once-only init with correct cross-thread ordering, less code.

## CI tooling

- **Memory tables always render.** The rocprof summary previously dropped the memory-copy/allocation tables silently when empty. They now show the data, an "N/A for the CPU backend" note, or a "no data captured — investigate" warning.
- **GPU jobs are gated.** The profiling workflow no longer runs GPU jobs on every PR. Post-merge pushes are path-filtered to tracing-relevant files; PRs run automatically on those paths or on demand via a `run-rocprof` label.

## Documentation

Added a "Profiling with rocprof / ROCTX" section to `amd_openvx/README.md`: build flag, runtime toggle, full `rocprofv3` command, a table explaining every range (with the async-launch caveat), Perfetto viewing, and the CI gating/label.

## Verification

Built and traced on both WSL (gfx1151) and a native ROCm box (santiago, gfx1100, RX 7900 XT):

- CPU-only build (macros compile away) — passes on both.
- HIP build with `-DMIVISIONX_ENABLE_ROCPROF=ON` — passes on both.
- On native GPU, `rocprofv3` confirmed the new ranges fire and correlate with the raw traces: `MIVisionX: GPU sync/wait` and `MIVisionX: copy-in ... param1/param2` appeared and matched the `MEMORY_COPY_HOST_TO_DEVICE` entries in the memory-copy trace, alongside existing per-node ranges, kernel dispatches, and allocations.

Notes: `copy-out` and `pipelined execution` compile and are placed identically to verified paths, but did not fire in the pure-GPU / non-pipelined test GDFs used — they need a mixed CPU/GPU-affinity graph and a pipelining graph respectively to exercise live.

## Test plan

- [ ] CI `ROCprof GDF profiling` workflow passes (gated run via `run-rocprof` label or tracing-path change)
- [ ] Default (non-ROCPROF) HIP and CPU builds unaffected