### PR TITLE
Fix amd_bytealign emulation to mask byte offset with & 3

### DIFF
--- a/amd_openvx/openvx/ago/ago_util_opencl.cpp
+++ b/amd_openvx/openvx/ago/ago_util_opencl.cpp
@@ -1496,7 +1496,7 @@ static void agoEmulateAmdMediaOpsInOpenCL(std::string& code)
             "#define amd_bitalign amd_bitalign_emu\n"
             "\n"
             "inline uint amd_bytealign_emu(uint src0,uint src1, uint src2){\n"
-            "	uint dst = (uint)(as_ulong((uint2)(src1,src0)) >> (src2 & 31) * 8 );\n"
+            "	uint dst = (uint)(as_ulong((uint2)(src1,src0)) >> (src2 & 3) * 8 );\n"
             "	return dst;\n"
             "}\n"
             "#define amd_bytealign amd_bytealign_emu\n"


### PR DESCRIPTION
## Summary

The software emulation of `amd_bytealign` in `agoEmulateAmdMediaOpsInOpenCL` masks the byte-offset argument with `& 31` instead of `& 3`. The hardware `amd_bytealign` uses only the low **2 bits** of the third argument to select a byte offset (0–3) into the concatenated `{src0:src1}` pair. Masking with `& 31` permits shifts of up to 31 bytes, so any call that passes a full (non pre-masked) byte index reads the wrong bytes whenever that index is `>= 4`.

```c
// before
uint dst = (uint)(as_ulong((uint2)(src1,src0)) >> (src2 & 31) * 8 );
// after
uint dst = (uint)(as_ulong((uint2)(src1,src0)) >> (src2 & 3) * 8 );
```

## Why this matters

This emulation is only injected when `cl_amd_media_ops` is **not** available (i.e. non-AMD OpenCL devices — the native AMD hardware path is untouched). On such devices, kernels that call `amd_bytealign` with a full byte index — e.g. the ORB Gaussian scale kernel (`HafGpu_ScaleGaussianOrb`) used by `vxGaussianPyramidNode` — compute incorrect pixels.

Discovered while running the OpenVX 1.3.2 Vision Conformance Test Suite against MIVisionX built with `-DBACKEND=OPENCL` on a non-AMD OpenCL device (PoCL CPU). The `amd_bytealign` output demonstrably changes with this fix (verified by dumping generated kernel output before/after).

`amd_bitalign` (a **bit** funnel shift, valid range 0–31 bits) correctly retains its `& 31` mask and is not changed.

## Scope / caveats

- Emulation-path-only change; **no effect on native AMD hardware** (native builtins are used there).
- This is a necessary, standalone correctness fix. It is **not by itself** sufficient to make every ORB-scale Gaussian pyramid conformance case pass on a non-AMD device — there appears to be a further row/column mapping difference in the ORB GPU kernel still under investigation. This PR is intentionally scoped to the clearly-correct `amd_bytealign` emulation bug.

## Test plan

- [x] Built MIVisionX `amd_openvx`/`vxu` with `-DBACKEND=OPENCL` on a non-AMD OpenCL device
- [x] Confirmed generated kernel emits `(src2 & 3) * 8` and output values change vs `& 31`
- [ ] Validate on native AMD hardware (emulation path not exercised there; native `amd_bytealign` unaffected)