### PR TITLE
Fix ScaleGaussianOrb local-memory read-after-write hazard

### DIFF
--- a/amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp
+++ b/amd_openvx/openvx/ago/ago_haf_gpu_special_filters.cpp
@@ -1644,7 +1644,7 @@ int HafGpu_ScaleGaussianOrb(AgoNode * node, vx_interpolation_type_e interpolatio
 			OPENCL_FORMAT(
 			"  __local uchar * lbuf_ptr = lbuf + ly * %d;\n" // LMemStride
 			"  float flx = mad((float)(lx << 2), %.12ef, fx + (float)lxalign);\n" // xscale
-			"  uint2 L0, isum; float fsum; uint ilx;\n"
+			"  uint2 L0, isum, isum2; float fsum; uint ilx;\n"
 			"  ilx = (uint)flx; L0 = vload2(0, (__local uint *)&lbuf_ptr[ilx & ~3]); L0.s0 = amd_bytealign(L0.s1, L0.s0, ilx); L0.s1 = amd_bytealign(L0.s1, L0.s1, ilx);\n"
 			"  fsum = amd_unpack0(L0.s0); fsum = mad(amd_unpack1(L0.s0), 4.0f, fsum); fsum = mad(amd_unpack2(L0.s0), 6.0f, fsum); fsum = mad(amd_unpack3(L0.s0), 4.0f, fsum); fsum += amd_unpack0(L0.s1);\n"
 			"  isum.s0 = (uint)fsum;\n"
@@ -1657,23 +1657,33 @@ int HafGpu_ScaleGaussianOrb(AgoNode * node, vx_interpolation_type_e interpolatio
 			"  ilx = (uint)(flx + %.12ef); L0 = vload2(0, (__local uint *)&lbuf_ptr[ilx & ~3]); L0.s0 = amd_bytealign(L0.s1, L0.s0, ilx); L0.s1 = amd_bytealign(L0.s1, L0.s1, ilx);\n" // xscale * 3
 			"  fsum = amd_unpack0(L0.s0); fsum = mad(amd_unpack1(L0.s0), 4.0f, fsum); fsum = mad(amd_unpack2(L0.s0), 6.0f, fsum); fsum = mad(amd_unpack3(L0.s0), 4.0f, fsum); fsum += amd_unpack0(L0.s1);\n"
 			"  isum.s1 |= (((uint)fsum) << 16);\n"
+			// Compute the extra (+16 rows) horizontal sums into a separate register
+			// BEFORE writing anything back to local memory. The horizontal reads
+			// (lbuf_ptr[ilx & ~3], neighbouring image pixels) and the write-back
+			// (((uint2*)lbuf_ptr)[lx]) alias the same local buffer, so storing before
+			// every work-item has finished reading corrupts neighbours' inputs. On a
+			// lock-step SIMD device the reads happen to complete first; on scalar
+			// devices (e.g. a CPU OpenCL driver) they do not, which produced wrong
+			// results. Finish all reads, barrier, then store.
+			"  if (ly < 7) {\n"
+			"    __local uchar * lbuf_ptr2 = lbuf_ptr + %d;\n" // LMemStride * 16
+			"    ilx = (uint)flx; L0 = vload2(0, (__local uint *)&lbuf_ptr2[ilx & ~3]); L0.s0 = amd_bytealign(L0.s1, L0.s0, ilx); L0.s1 = amd_bytealign(L0.s1, L0.s1, ilx);\n"
+			"    fsum = amd_unpack0(L0.s0); fsum = mad(amd_unpack1(L0.s0), 4.0f, fsum); fsum = mad(amd_unpack2(L0.s0), 6.0f, fsum); fsum = mad(amd_unpack3(L0.s0), 4.0f, fsum); fsum += amd_unpack0(L0.s1);\n"
+			"    isum2.s0 = (uint)fsum;\n"
+			"    ilx = (uint)(flx + %.12ef); L0 = vload2(0, (__local uint *)&lbuf_ptr2[ilx & ~3]); L0.s0 = amd_bytealign(L0.s1, L0.s0, ilx); L0.s1 = amd_bytealign(L0.s1, L0.s1, ilx);\n" // xscale
+			"    fsum = amd_unpack0(L0.s0); fsum = mad(amd_unpack1(L0.s0), 4.0f, fsum); fsum = mad(amd_unpack2(L0.s0), 6.0f, fsum); fsum = mad(amd_unpack3(L0.s0), 4.0f, fsum); fsum += amd_unpack0(L0.s1);\n"
+			"    isum2.s0 |= (((uint)fsum) << 16);\n"
+			"    ilx = (uint)(flx + %.12ef); L0 = vload2(0, (__local uint *)&lbuf_ptr2[ilx & ~3]); L0.s0 = amd_bytealign(L0.s1, L0.s0, ilx); L0.s1 = amd_bytealign(L0.s1, L0.s1, ilx);\n" // xscale * 2
+			"    fsum = amd_unpack0(L0.s0); fsum = mad(amd_unpack1(L0.s0), 4.0f, fsum); fsum = mad(amd_unpack2(L0.s0), 6.0f, fsum); fsum = mad(amd_unpack3(L0.s0), 4.0f, fsum); fsum += amd_unpack0(L0.s1);\n"
+			"    isum2.s1 = (uint)fsum;\n"
+			"    ilx = (uint)(flx + %.12ef); L0 = vload2(0, (__local uint *)&lbuf_ptr2[ilx & ~3]); L0.s0 = amd_bytealign(L0.s1, L0.s0, ilx); L0.s1 = amd_bytealign(L0.s1, L0.s1, ilx);\n" // xscale * 3
+			"    fsum = amd_unpack0(L0.s0); fsum = mad(amd_unpack1(L0.s0), 4.0f, fsum); fsum = mad(amd_unpack2(L0.s0), 6.0f, fsum); fsum = mad(amd_unpack3(L0.s0), 4.0f, fsum); fsum += amd_unpack0(L0.s1);\n"
+			"    isum2.s1 |= (((uint)fsum) << 16);\n"
+			"  }\n"
+			"  barrier(CLK_LOCAL_MEM_FENCE);\n"
 			"  ((__local uint2 *)lbuf_ptr)[lx] = isum;\n"
 			"  if (ly < 7) {\n"
-			"    lbuf_ptr += %d;\n" // LMemStride * 16
-			"    ilx = (uint)flx; L0 = vload2(0, (__local uint *)&lbuf_ptr[ilx & ~3]); L0.s0 = amd_bytealign(L0.s1, L0.s0, ilx); L0.s1 = amd_bytealign(L0.s1, L0.s1, ilx);\n"
-			"    fsum = amd_unpack0(L0.s0); fsum = mad(amd_unpack1(L0.s0), 4.0f, fsum); fsum = mad(amd_unpack2(L0.s0), 6.0f, fsum); fsum = mad(amd_unpack3(L0.s0), 4.0f, fsum); fsum += amd_unpack0(L0.s1);\n"
-			"    isum.s0 = (uint)fsum;\n"
-			"    ilx = (uint)(flx + %.12ef); L0 = vload2(0, (__local uint *)&lbuf_ptr[ilx & ~3]); L0.s0 = amd_bytealign(L0.s1, L0.s0, ilx); L0.s1 = amd_bytealign(L0.s1, L0.s1, ilx);\n" // xscale
-			"    fsum = amd_unpack0(L0.s0); fsum = mad(amd_unpack1(L0.s0), 4.0f, fsum); fsum = mad(amd_unpack2(L0.s0), 6.0f, fsum); fsum = mad(amd_unpack3(L0.s0), 4.0f, fsum); fsum += amd_unpack0(L0.s1);\n"
-			"    isum.s0 |= (((uint)fsum) << 16);\n"
-			"    ilx = (uint)(flx + %.12ef); L0 = vload2(0, (__local uint *)&lbuf_ptr[ilx & ~3]); L0.s0 = amd_bytealign(L0.s1, L0.s0, ilx); L0.s1 = amd_bytealign(L0.s1, L0.s1, ilx);\n" // xscale * 2
-			"    fsum = amd_unpack0(L0.s0); fsum = mad(amd_unpack1(L0.s0), 4.0f, fsum); fsum = mad(amd_unpack2(L0.s0), 6.0f, fsum); fsum = mad(amd_unpack3(L0.s0), 4.0f, fsum); fsum += amd_unpack0(L0.s1);\n"
-			"    isum.s1 = (uint)fsum;\n"
-			"    ilx = (uint)(flx + %.12ef); L0 = vload2(0, (__local uint *)&lbuf_ptr[ilx & ~3]); L0.s0 = amd_bytealign(L0.s1, L0.s0, ilx); L0.s1 = amd_bytealign(L0.s1, L0.s1, ilx);\n" // xscale * 3
-			"    fsum = amd_unpack0(L0.s0); fsum = mad(amd_unpack1(L0.s0), 4.0f, fsum); fsum = mad(amd_unpack2(L0.s0), 6.0f, fsum); fsum = mad(amd_unpack3(L0.s0), 4.0f, fsum); fsum += amd_unpack0(L0.s1);\n"
-			"    isum.s1 |= (((uint)fsum) << 16);\n"
-			"    ((__local uint2 *)lbuf_ptr)[lx] = isum;\n"
-			"    lbuf_ptr -= %d;\n" // LMemStride * 16
+			"    ((__local uint2 *)(lbuf_ptr + %d))[lx] = isum2;\n" // LMemStride * 16
 			"  }\n"
 			"  barrier(CLK_LOCAL_MEM_FENCE);\n"
 			"  float fly = fy + (float)ly * %.12ef; float4 sum;\n" // yscale


### PR DESCRIPTION
## Summary

The OpenCL codegen for the ORB Gaussian scale kernel (`HafGpu_ScaleGaussianOrb`, used by `vxGaussianPyramidNode` with `VX_SCALE_PYRAMID_ORB`) performs the horizontal filter **in place** in local memory, with a read-after-write hazard: each work-item reads neighbouring image pixels from the local buffer **and**, in the same pass with no barrier, writes its packed 16-bit horizontal sums back to the *same* local buffer.

```
// reads image pixels:            lbuf_ptr[ilx & ~3]     (via vload2)
// writes 16-bit sums to same buf: ((uint2*)lbuf_ptr)[lx] = isum;   // no barrier between
```

Because one work-item's read footprint overlaps its neighbours' write footprint (e.g. `lx=2` reads local bytes `[8..19]` while `lx=1` writes `[8..15]`), a work-item can read sums another work-item already wrote instead of the original pixels.

- On a **lock-step SIMD** device the reads complete before the writes land, so the output was correct.
- On a **scalar / non-lock-step** device (e.g. a CPU OpenCL driver such as PoCL) the writes race ahead and corrupt the result — the right-hand output columns come out wrong.

## Fix

Compute both the main-row and the `+16`-row horizontal sums into private registers (`isum`, `isum2`), then `barrier(CLK_LOCAL_MEM_FENCE)`, then store. All reads of the shared local buffer complete before any work-item writes to it.

This also avoids a `barrier` inside the divergent `if (ly < 7)` block (the stores are now issued in uniform control flow).

## Validation

Built MIVisionX with `-DBACKEND=OPENCL` and ran the OpenVX 1.3.2 Vision CTS.

- **AMD Radeon gfx1151 (ROCm OpenCL):** no behavioural change — `GaussianPyramid` ORB stays **12/12**, full vision suite unchanged.
- **PoCL CPU device:** fixes the 8 `GaussianPyramid … VX_BORDER_UNDEFINED … VX_SCALE_PYRAMID_ORB` cases that previously failed. Full vision conformance now passes **5824/5824**, up from 5816/5824.

Isolated by running the identical generated kernel on both runtimes and bisecting the intermediate state (loaded local buffer, sample indices, and first filter tap were all identical between PoCL and AMD; only the post-store horizontal result diverged), then confirming a `barrier` before the store makes PoCL match AMD byte-for-byte.

Related: ROCm/MIVisionX#1526 (PoCL conformance tracking), ROCm/MIVisionX#1750 (earlier `amd_bytealign` emulation fix on the same non-lock-step path).

## Test plan

- [x] `GaussianPyramid` ORB: 12/12 on PoCL (was 4/12) and 12/12 on AMD gfx1151 (unchanged)
- [x] Full vision CTS on PoCL: 5824/5824, 0 fail
- [x] No regression on AMD gfx1151